### PR TITLE
make accept optional for response_translation

### DIFF
--- a/templates/translation.cfg.xml.erb
+++ b/templates/translation.cfg.xml.erb
@@ -27,7 +27,9 @@
             code-regex="<%= response_translation['code_regex'] %>"
     <%- end -%>
             content-type="<%= response_translation['content_type'] %>" 
+    <%- if response_translation['accept'] -%>
             accept="<%= response_translation['accept'] %>"
+    <%- end -%>
             translated-content-type="<%= response_translation['translated_content_type'] %>">
             <style-sheets>
     <% response_translation['styles'].each do |style| %>


### PR DESCRIPTION
According to Repose XSD:
https://github.com/rackerlabs/repose/blob/master/repose-aggregator/components/filters/translation/src/main/resources/META-INF/schema/config/translation-configuration.xsd

The accept is optional.

Especially for response translation, accept does not make sense since servers don't usually send back Accept header. 

When we configure response translation, if we don't specify accept, it comes up with accept="".
