### PR TITLE
adding id attribute to limit for rate limiting

### DIFF
--- a/manifests/filter/rate_limiting.pp
+++ b/manifests/filter/rate_limiting.pp
@@ -40,7 +40,9 @@
 # Required Array of hashes.  Hashes should contain
 #   String(id), String(groups), Boolean(default), and ArrayofHashes(limits)
 # Where the hashes in limits should contain the Strings:
-#   uri, uri-regex, http-methods, unit, value
+#   uri, uri-regex, http-methods, unit, value, id
+# NOTE: the id in limits array  should only be used with repose 5.0.0+.
+# Setting id <5.0.0 will result in the error.
 #
 # === Links
 #

--- a/templates/rate-limiting.cfg.xml.erb
+++ b/templates/rate-limiting.cfg.xml.erb
@@ -13,7 +13,7 @@
     <limit-group id="<%= limit_group['id'] %>" groups="<%= limit_group['groups'] %>" default="<%= limit_group['default'] %>">
   <%- if limit_group.has_key?('limits') -%>
     <%- limit_group['limits'].each do |limit| %>
-      <limit uri="<%= limit['uri'] %>" uri-regex="<%= limit['uri_regex'] %>" http-methods="<%= limit['http_methods'] %>" unit="<%= limit['unit'] %>" value="<%= limit['value'] %>" />
+        <limit <% if limit.has_key?('id') %>id="<%= limit['id'] %>" <% end %>uri="<%= limit['uri'] %>" uri-regex="<%= limit['uri_regex'] %>" http-methods="<%= limit['http_methods'] %>" unit="<%= limit['unit'] %>" value="<%= limit['value'] %>" />
     <%- end -%>
   <%- end -%>
     </limit-group>


### PR DESCRIPTION
Starting with repose 5.0.0, the limit entry in the rate limit config needs a unique id defined.  This adds support for the id attribute.
