### PR TITLE
adding syslog support to log4j

### DIFF
--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -21,8 +21,82 @@
 # String. Default log level
 # Defaults to <tt>WARN</tt>
 #
+# [*syslog_server*]
+# String.  If this host is provided, the repose log4j configuration will ship
+# the repose.log to syslog (facility LOCAL0) and a http logger is created
+# for the SLF5J http logger filter (facility LOCAL1).
+# Defaults to <tt>undef</tt> which will disable syslog sending.
+#
+# [*syslog_port*]
+# Integer. Port to send syslog traffic to.
+# Defaults to <tt>514</tt>
+#
+# [*syslog_protocol*]
+# String. The protocol to send syslog traffic as. Should be 'tcp' or 'udp'.
+# Defaults to <tt>udp</tt>
+#
+# [*via*]
+# String. String used in the Via header.
+# Defaults to <tt>undef</tt>
+#
+# [*deployment_directory*]
+# String. A string that points the directory where artifacts are extracted.
+# Defaults to <tt>/var/repose</tt>
+#
+# [*deployment_directory_auto_clean*]
+# Boolean. Set to true to clean up undeployed resources.
+# Defaults to <tt>true</tt>
+#
+# [*artifact_directory*]
+# String.
+# Defaults to <tt>/usr/share/repose/filters</tt>
+#
+# [*artifact_directory_check_interval*]
+# Integer. Directory check interval in milliseconds.
+# Defaults to <tt>60000</tt>
+#
+# [*logging_configuration*]
+# String. The name of the logging configuration file.
+# Defaults to <tt>log4j.properties</tt>
+#
+# [*ssl_enabled*]
+# Boolean. Enable ssl configuration for the container.
+# Defaults to <tt>false</tt>
+#
+# [*ssl_keystore_filename*]
+# String. The name of the application keystore file, e.g. keystore.repose
+# Defaults to <tt>undef</tt>
+#
+# [*ssl_keystore_password*]
+# String. The password for the entire application keystore
+# Defaults to <tt>undef</tt>
+#
+# [*ssl_key_password*]
+# String. The password for the particular application key in the keystore.
+# Defaults to <tt>undef</tt>
+#
+# [*http_port*]
+# DEPRECATED. This attribute is deprecated and will be ignored. This has
+# moved to the system-model configuration.
+#
+# [*https_port*]
+# DEPRECATED. This attribute is deprecated and will be ignored. This has
+# moved to the system-model configuration.
+#
+# [*connection_timeout*]
+# DEPRECATED. This attribute is deprecated and moved to the
+# http-connection-pool configuration.
+#
+# [*read_timeout*]
+# DEPRECATED. This attribute is deprecated and moved to the
+# http-connection-pool configuration.
+#
+# [*proxy_thread_pool*]
+# DEPRECATED. This attribute is deprecated and moved to the
+# http-connection-pool configuration.
+#
 # [*client_request_logging*]
-# Bool. Log the client request
+# DEPRECATED. Bool. Log the client request
 # Defaults to <tt>false</tt>
 #
 # === Examples
@@ -38,11 +112,30 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose::filter::container (
-  $ensure                 = present,
-  $app_name               = undef,
-  $log_dir                = $repose::params::logdir,
-  $log_level              = 'WARN',
-  $client_request_logging = false,
+  $ensure                            = present,
+  $app_name                          = undef,
+  $log_dir                           = $repose::params::logdir,
+  $log_level                         = $repose::params::log_level,
+  $syslog_server                     = undef,
+  $syslog_port                       = $repose::params::syslog_port,
+  $syslog_protocol                   = $repose::params::syslog_protocol,
+  $via                               = undef,
+  $deployment_directory              = $repose::params::deployment_directory,
+  $deployment_directory_auto_clean   = true,
+  $artifact_directory                = $repose::params::artifact_directory,
+  $artifact_directory_check_interval = 60000,
+  $logging_configuration             = $repose::params::logging_configuration,
+  $ssl_enabled                       = false,
+  $ssl_keystore_filename             = undef,
+  $ssl_keystore_password             = undef,
+  $ssl_key_password                  = undef,
+  $client_request_logging            = undef,
+  $http_port                         = undef,
+  $https_port                        = undef,
+  $connection_timeout                = undef,
+  $read_timeout                      = undef,
+  $proxy_thread_pool                 = undef,
+  $client_request_logging            = undef,
 ) inherits repose::params {
 
 ### Validate parameters
@@ -74,7 +167,7 @@ class repose::filter::container (
     require => Package['repose-filters'],
   }
 
-  file { "${repose::params::configdir}/log4j.properties":
+  file { "${repose::params::configdir}/${logging_configuration}":
     ensure  => file,
     content => template('repose/log4j.properties.erb')
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -134,4 +134,23 @@ class repose::params {
 
 ## run ops for repose-valve
   $run_opts = '-s $SHUTDOWN_PORT -p $RUN_PORT -c $CONFIG_DIRECTORY'
+
+## container deployment directory
+  $deployment_directory = '/var/repose'
+
+## container artifact directory
+  $artifact_directory = '/usr/share/repose/filters'
+
+## syslog_port
+  $syslog_port = 514
+
+## syslog_protocol
+  $syslog_protocol = 'udp'
+
+## logging configuration file
+  $logging_configuration = 'log4j.properties'
+
+## default log level
+  $log_level = 'WARN'
+
 }

--- a/templates/container.cfg.xml.erb
+++ b/templates/container.cfg.xml.erb
@@ -2,14 +2,49 @@
 
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
 <repose-container xmlns='http://docs.rackspacecloud.com/repose/container/v2.0'>
-    <deployment-config http-port="8080" connection-timeout="30000" read-timeout="600000" client-request-logging="<%= client_request_logging -%>">
+    <deployment-config
+<%- if @http_port -%>
+        http-port="<%= @http_port %>"
+<%- end -%>
+<%- if @https_port -%>
+        https-port="<%= @https_port %>"
+<%- end -%>
+<%- if @via -%>
+        via="<%= @via %>"
+<%- end -%>
+<%- if @content_body_read_limit -%>
+        content-body-read-limit="<%= @content_body_read_limit %>"
+<%- end -%>
+<%- if @connection_timeout -%>
+        connection-timeout="<%= @connection_timeout %>"
+<%- end -%>
+<%- if @read_timeout -%>
+        read-timeout="<%= @read_timeout %>"
+<%- end -%>
+<%- if @proxy_thread_pool -%>
+        proxy-thread-pool="<%= @proxy_thread_pool %>"
+<%- end -%>
+<%- if @client_request_logging -%>
+        client-request-logging="<%= @client_request_logging -%>"
+<%- end -%>
+<%- if @jmx_reset_time -%>
+        jmx-reset-time="<%= @jmx_reset_time -%>"
+<%- end -%>
+        >
 
-        <deployment-directory auto-clean="true">/var/repose</deployment-directory>
+        <deployment-directory auto-clean="<%= @deployment_directory_auto_clean %>"><%= @deployment_directory %></deployment-directory>
 
-        <artifact-directory check-interval="60000">/usr/share/repose/filters</artifact-directory>
+        <artifact-directory check-interval="<%= @artifact_directory_check_interval %>"><%= @artifact_directory %></artifact-directory>
 
-        <logging-configuration href="log4j.properties"/>
+        <logging-configuration href="<%= @logging_configuration %>"/>
 
+<%- if @ssl_enabled == true -%>
+        <ssl-configuration>
+            <keystore-filename><%= @ssl_keystore_filename %></keystore-filename>
+            <keystore-password><%= @ssl_keystore_password %></keystore-password>
+            <key-password><%= @ssl_key_password %></key-password>
+        </ssl-configuration>
+<%- end -%>
     </deployment-config>
 </repose-container>
 

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -1,5 +1,13 @@
+<%-
+# if syslog_server is provided, then add it to the root appenders
+if @syslog_server
+  rootAppenders = [ "syslog", "defaultFile" ]
+else
+  rootAppenders = [ "defaultFile" ]
+end
+-%>
 # Set root logger level
-log4j.rootLogger=<%= log_level %>, defaultFile
+log4j.rootLogger=<%= log_level %>, <%= rootAppenders.join(", ") %>
 
 # Console
 #log4j.appender.consoleOut=org.apache.log4j.ConsoleAppender
@@ -16,3 +24,26 @@ log4j.appender.defaultFile.DatePattern=.yyyy-MM-dd
 log4j.appender.defaultFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.defaultFile.maxBackupIndex=5
 log4j.appender.defaultFile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n
+
+<%- if @syslog_server -%>
+log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
+log4j.appender.syslog.Facility=local0
+log4j.appender.syslog.FacilityPrinting=false
+log4j.appender.syslog.Header=true
+log4j.appender.syslog.syslogHost=<%= @syslog_server %>
+log4j.appender.syslog.port=<%= @syslog_port %>
+log4j.appender.syslog.protocol=<%= @syslog_protocol %>
+log4j.appender.syslog.layout=org.apache.log4j.PatternLayout
+log4j.appender.syslog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n
+
+log4j.logger.http=INFO, httpSyslog
+log4j.appender.httpSyslog=org.apache.log4j.net.SyslogAppender
+log4j.appender.httpSyslog.Facility=local1
+log4j.appender.httpSyslog.FacilityPrinting=false
+log4j.appender.httpSyslog.Header=true
+log4j.appender.httpSyslog.syslogHost=<%= @syslog_server %>
+log4j.appender.httpSyslog.port=<%= @syslog_port %>
+log4j.appender.httpSyslog.protocol=<%= @syslog_protocol %>
+log4j.appender.httpSyslog.layout=org.apache.log4j.PatternLayout
+log4j.appender.httpSyslog.layout.ConversionPattern=%m%n
+<%- end -%>


### PR DESCRIPTION
This PR includes adding syslog support into the log4j.properties for repose-valve.  Additionally we have exposed all the parameters that are available in the containers.cfg.xml.  These additional parameters add the parameters for configuring ssl support.  Also making some of these parameters optional cleans up the deprecated warning that shows up when you configure some "connection-timeout", "read-timeout", and "proxy-thread-pool" within the container.cfg.xml in newer versions of repose.
