### PR TITLE
B-47914: add token-cache-timeout to Repose config

### DIFF
--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -70,6 +70,7 @@ define repose::filter::client_auth_n (
   $white_lists         = undef,
   $delegable           = false,
   $tenanted            = false,
+  $token_cache_timeout = undef,
   $group_cache_timeout = '60000',
   $connection_pool_id  = undef,
 ) {

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
-    <openstack-auth delegable="<%= @delegable %>" tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+    <openstack-auth delegable="<%= @delegable %>" tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
         <identity-service username="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>" uri="<%= @auth['uri'] -%>" />
 <%- if @client_maps -%>
   <% @client_maps.each do |client_map| -%>


### PR DESCRIPTION
Cloud Feeds will be tweaking the default value of token-cache-timeout in our customer facing client auth. We need this config to be exposed in Repose puppet module.
