### PR TITLE
Deprecation of http-logging filter

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.0.6'
+version '1.0.7'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,7 +11,7 @@ This module provides a re-usable and environment agnostic control of Repose Powe
   $api_protocol = 'https'
   $api_host     = "api-internal.${::domain}"
   $api_port     = '443'
-  $api_uri  = "${api_protocol}://${api_host}/${app_name}"
+  $api_uri      = "${api_protocol}://${api_host}/${app_name}"
   $repose_nodes = [ "repose-n01.${::domain}",
                     "repose-n02.${::domain}" ]
 
@@ -26,15 +26,14 @@ This module provides a re-usable and environment agnostic control of Repose Powe
 
   # Your http logging definitions
   $log_files = [
-    { 'id'   => 'http-log',
-      'format'   => "Response Code Modifiers=%200,201U\tModifier Negation=%!401a\tRemote IP=%a\tLocal IP=%A\tResponse Size(bytes)=%b",
-      'location' => "/var/log/repose/http_repose.log",
+    { 'id'     => 'http',
+      'format' => 'Response Code Modifiers=%200,201U\tModifier Negation=%!401a\tRemote IP=%a\tLocal IP=%A\tResponse Size(bytes)=%b',
     },
   ]
 
   # Your definitions for the system model
   $filters = {
-      10 => { 'name'      => 'http-logging' },
+      10 => { 'name'      => 'slf4j-http-logging' },
       20 => { 'name'      => 'client-auth',
               'uri-regex' => "/${app_name}/.*" },
       30 => { 'name'      => 'default-router' },
@@ -51,7 +50,7 @@ This module provides a re-usable and environment agnostic control of Repose Powe
 
   # Bringing it all together
   class { 'repose::valve': }
-  repose::filter::http_logging { 'default':
+  repose::filter::slf4j_http_logging { 'default':
     log_files => $log_files,
   }
   repose::filter::client_auth_n { 'default':

--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -13,6 +13,55 @@
 # String. Application name. Required
 # Defaults to <tt>undef</tt>
 #
+# [*artifact_directory*]
+# String.
+# Defaults to <tt>/usr/share/repose/filters</tt>
+#
+# [*artifact_directory_check_interval*]
+# Integer. Directory check interval in milliseconds.
+# Defaults to <tt>60000</tt>
+#
+# [*client_request_logging*]
+# Bool. Logs communication between repose and the end service
+# Defaults to <tt>false</tt>
+#
+# [*content_body_read_limit*]
+# Integer. Maximum size ofr request content in bytes
+# Defaults to <tt>undef</tt>
+#
+# [*deployment_directory*]
+# String. A string that points the directory where artifacts are extracted.
+# Defaults to <tt>/var/repose</tt>
+#
+# [*deployment_directory_auto_clean*]
+# Boolean. Set to true to clean up undeployed resources.
+# Defaults to <tt>true</tt>
+#
+# [*jmx_reset_time*]
+# Integer. The number of seconds the JMX reporting service keeps
+# data. The data will be reset after this amount of time.
+# Defaults to <tt>undef</tt>
+#
+# [*log_access_facility*]
+# String. The facility to use when sending access logs via syslog.
+# Defaults to <tt>local1</tt>
+#
+# [*log_access_local*]
+# Boolean. Should repose access logs be logged locally. Uses the log_local_*
+# Settings to determine retention policy.
+# Defaults to <tt>true</tt>
+#
+# [*log_access_local_name*]
+# String. The name of the local log file to be created for the local http
+# access logs. The name is appended with .log.
+# Defaults to <tt>http_repose</tt>
+#
+# [*log_access_syslog*]
+# Boolean. Should repose access logs be to a syslog. Uses the syslog_*
+# Settings to determine where to send the logs. You must also specify
+# a syslog_server in order for this to be enabled.
+# Defaults to <tt>true</tt>
+#
 # [*log_dir*]
 # String. Log file directory
 # Defaults to <tt>/var/log/repose</tt>
@@ -20,6 +69,33 @@
 # [*log_level*]
 # String. Default log level
 # Defaults to <tt>WARN</tt>
+#
+# [*log_local_policy*]
+# String. Log policy for repose.log and http_access.log.  Default setting uses
+# the log4j DailyRollingFileAppender with a suffix of .yyyy-MM-dd.  Can be one
+# of <tt>date</tt>,<tt>size</tt>,<tt>undef</tt>.  If set to size, the logs
+# are rotated based on size and use the <tt>log_local_size</tt> and
+# <tt>log_local_rotation_count</tt> for determining retention.  If set to
+# <tt>undef</tt> or anything other than <tt>date</tt> or <tt>size</tt>
+# the NullAppender is used which means it won't log.
+# Defaults to <tt>date</tt>
+#
+# [*log_local_size*]
+# String. The max file size for the log4j RollingFileAppender.
+# Defaults to <tt>100M</tt>
+#
+# [*log_local_rotation_count*]
+# Integer. The number of backup files to keeo for the log4j RollingFileAppender
+# Defaults to <tt>4</tt>
+#
+# [*log_repose_facility*]
+# String. The logging facility to send repose logs to when sending to a syslog
+# server.
+# Defaults to <tt>local0</tt>
+#
+# [*logging_configuration*]
+# String. The name of the logging configuration file.
+# Defaults to <tt>log4j.properties</tt>
 #
 # [*syslog_server*]
 # String.  If this host is provided, the repose log4j configuration will ship
@@ -34,30 +110,6 @@
 # [*syslog_protocol*]
 # String. The protocol to send syslog traffic as. Should be 'tcp' or 'udp'.
 # Defaults to <tt>udp</tt>
-#
-# [*via*]
-# String. String used in the Via header.
-# Defaults to <tt>undef</tt>
-#
-# [*deployment_directory*]
-# String. A string that points the directory where artifacts are extracted.
-# Defaults to <tt>/var/repose</tt>
-#
-# [*deployment_directory_auto_clean*]
-# Boolean. Set to true to clean up undeployed resources.
-# Defaults to <tt>true</tt>
-#
-# [*artifact_directory*]
-# String.
-# Defaults to <tt>/usr/share/repose/filters</tt>
-#
-# [*artifact_directory_check_interval*]
-# Integer. Directory check interval in milliseconds.
-# Defaults to <tt>60000</tt>
-#
-# [*logging_configuration*]
-# String. The name of the logging configuration file.
-# Defaults to <tt>log4j.properties</tt>
 #
 # [*ssl_enabled*]
 # Boolean. Enable ssl configuration for the container.
@@ -75,18 +127,9 @@
 # String. The password for the particular application key in the keystore.
 # Defaults to <tt>undef</tt>
 #
-# [*content_body_read_limit*]
-# Integer. Maximum size ofr request content in bytes
+# [*via*]
+# String. String used in the Via header.
 # Defaults to <tt>undef</tt>
-#
-# [*jmx_reset_time*]
-# Integer. The number of seconds the JMX reporting service keeps
-# data. The data will be reset after this amount of time.
-# Defaults to <tt>undef</tt>
-#
-# [*client_request_logging*]
-# Bool. Logs communication between repose and the end service
-# Defaults to <tt>false</tt>
 #
 # [*http_port*]
 # DEPRECATED. This attribute is deprecated and will be ignored. This has
@@ -123,24 +166,33 @@
 class repose::filter::container (
   $ensure                            = present,
   $app_name                          = undef,
-  $log_dir                           = $repose::params::logdir,
-  $log_level                         = $repose::params::log_level,
-  $syslog_server                     = undef,
-  $syslog_port                       = $repose::params::syslog_port,
-  $syslog_protocol                   = $repose::params::syslog_protocol,
-  $via                               = undef,
-  $deployment_directory              = $repose::params::deployment_directory,
-  $deployment_directory_auto_clean   = true,
   $artifact_directory                = $repose::params::artifact_directory,
   $artifact_directory_check_interval = 60000,
+  $client_request_logging            = undef,
+  $content_body_read_limit           = undef,
+  $deployment_directory              = $repose::params::deployment_directory,
+  $deployment_directory_auto_clean   = true,
+  $jmx_reset_time                    = undef,
+  $log_access_facility               = $repose::params::log_access_facility,
+  $log_access_local                  = $repose::params::log_access_local,
+  $log_access_local_name             = $repose::params::log_access_local_name,
+  $log_access_syslog                 = $repose::params::log_access_syslog,
+  $log_dir                           = $repose::params::logdir,
+  $log_level                         = $repose::params::log_level,
+  $log_local_policy                  = $repose::params::log_local_policy,
+  $log_local_size                    = $repose::params::log_local_size,
+  $log_local_rotation_count          = $repose::params::log_local_rotation_count,
+  $log_repose_facility               = $repose::params::log_repose_facility,
   $logging_configuration             = $repose::params::logging_configuration,
   $ssl_enabled                       = false,
   $ssl_keystore_filename             = undef,
   $ssl_keystore_password             = undef,
   $ssl_key_password                  = undef,
-  $content_body_read_limit           = undef,
-  $jmx_reset_time                    = undef,
-  $client_request_logging            = undef,
+  $syslog_server                     = undef,
+  $syslog_port                       = $repose::params::syslog_port,
+  $syslog_protocol                   = $repose::params::syslog_protocol,
+  $via                               = undef,
+  # BELOW ARE DEPRECATED
   $http_port                         = undef,
   $https_port                        = undef,
   $connection_timeout                = undef,
@@ -149,6 +201,13 @@ class repose::filter::container (
 ) inherits repose::params {
 
 ### Validate parameters
+  validate_bool($log_access_local)
+  validate_bool($log_access_syslog)
+  validate_string($log_access_facility)
+  validate_string($log_dir)
+  validate_string($log_level)
+  validate_string($log_access_local_name)
+  validate_string($log_syslog_facility)
 
 ## ensure
   if ! ($ensure in [ present, absent ]) {

--- a/manifests/filter/http_logging.pp
+++ b/manifests/filter/http_logging.pp
@@ -1,5 +1,8 @@
 # == Resource: repose::filter::http_logging
 #
+# *DEPRECATED* THIS FILTER HAS BEEN DEPRECATED.
+# This filter has been replaced with the slf4j http logging filter. Please
+# update to use repose::filters::slf4j_http_logging
 # This is a resource for generating http logging configuration files
 #
 # === Parameters
@@ -55,6 +58,7 @@ define repose::filter::http_logging (
   $filename  = 'http-logging.cfg.xml',
   $log_files = undef,
 ) {
+  warning('repose::filter::http_logging has been deprecated')
 
 ### Validate parameters
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,4 +153,27 @@ class repose::params {
 ## default log level
   $log_level = 'WARN'
 
+## default local log policy
+  $log_local_policy = 'date'
+
+## default local log size
+  $log_local_size = '100M'
+
+## default local log rotation count
+  $log_local_rotation_count = 4
+
+## default repose.log syslog facility
+  $log_repose_facility = 'local0'
+
+## default http access log syslog facility
+  $log_access_facility = 'local1'
+
+## default access logging locally
+  $log_access_local = true
+
+## default access log local filename
+  $log_access_local_name = 'http_repose'
+
+## default access logging to syslog
+  $log_access_syslog = true
 }

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -1,7 +1,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{base_name}
-Version:   1.0.6
+Version:   1.0.7
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -29,6 +29,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Tue Sep 15 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.0.7-1
+- Deprecation of http-logging filter, updates to log4j to support slf4j logging
 * Tue Jun 03 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.0.6-1
 - Fixing minor logic issues, adding spec tests
 * Mon May 19 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.0.5-1

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -118,7 +118,8 @@ describe 'repose::filter::client_auth_n', :type => :define do
         )
         should contain_file('/etc/repose/client-auth-n.cfg.xml').
           with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
-          with_content(/ignore-tenant-roles=\"role\"/)
+          with_content(/ignore-tenant-roles/).
+          with_content(/<role>role<\/role>/)
       }
     end
 

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -18,12 +18,19 @@ log4j.rootLogger=<%= @log_level %>, <%= rootAppenders.join(", ") %>
 #log4j.logger.org.eclipse.jetty=OFF
 
 # File
+<%- if @log_local_policy == 'date' %>
 log4j.appender.defaultFile=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.defaultFile.DatePattern=.yyyy-MM-dd
+<%- elsif @log_local_policy == 'size' %>
+log4j.appender.defaultFile=org.apache.log4j.RollingFileAppender
+log4j.appender.defaultFile.maxFileSize=<%= @log_local_size %>
+log4j.appender.defaultFile.maxBackupIndex=<%= @log_local_rotation_count %>
+<%- else %>
+log4j.appender.defaultFile=org.apache.log4j.varia.NullAppender
+<%- end %>
 log4j.appender.defaultFile.File=<%= @log_dir-%>/<%= @app_name -%>.log
 log4j.appender.defaultFile.Threshold=<%= @log_level %>
-log4j.appender.defaultFile.DatePattern=.yyyy-MM-dd
 log4j.appender.defaultFile.layout=org.apache.log4j.PatternLayout
-log4j.appender.defaultFile.maxBackupIndex=5
 log4j.appender.defaultFile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n
 
 <%- if @syslog_server -%>
@@ -37,8 +44,20 @@ log4j.appender.syslog.port=<%= @syslog_port %>
 log4j.appender.syslog.protocol=<%= @syslog_protocol %>
 log4j.appender.syslog.layout=org.apache.log4j.PatternLayout
 log4j.appender.syslog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n
+<%- end -%>
 
-log4j.logger.http=INFO, httpSyslog
+<%-
+# if setup the appropriate access log appenders
+httpAppenders = Array.new()
+if @log_access_syslog and @syslog_server
+  httpAppenders.push("httpSyslog")
+end
+if @log_access_local
+  httpAppenders.push("httpLocal")
+end
+-%>
+log4j.logger.http=INFO, <%= httpAppenders.join(", ") %>
+<%- if @log_access_syslog and @syslog_server %>
 log4j.appender.httpSyslog=org.apache.log4j.net.SyslogAppender
 log4j.appender.httpSyslog.Facility=local1
 log4j.appender.httpSyslog.FacilityPrinting=false
@@ -48,4 +67,20 @@ log4j.appender.httpSyslog.port=<%= @syslog_port %>
 log4j.appender.httpSyslog.protocol=<%= @syslog_protocol %>
 log4j.appender.httpSyslog.layout=org.apache.log4j.PatternLayout
 log4j.appender.httpSyslog.layout.ConversionPattern=%m%n
-<%- end -%>
+<%- end %>
+
+<%- if @log_access_local %>
+<%- if @log_local_policy == 'date' %>
+log4j.appender.httpLocal=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.httpLocal.DatePattern=.yyyy-MM-dd
+<%- elsif @log_local_policy == 'size' %>
+log4j.appender.httpLocal=org.apache.log4j.RollingFileAppender
+log4j.appender.httpLocal.maxFileSize=<%= @log_local_size %>
+log4j.appender.httpLocal.maxBackupIndex=<%= @log_local_rotation_count %>
+<%- else %>
+log4j.appender.httpLocal=org.apache.log4j.varia.NullAppender
+<%- end %>
+log4j.appender.httpLocal.File=<%= @log_dir -%>/<%= @log_access_local_name %>.log
+log4j.appender.httpLocal.layout=org.apache.log4j.PatternLayout
+log4j.appender.httpLocal.layout.ConversionPattern=%m%n
+<%- end %>


### PR DESCRIPTION
- Updates to the log4j settings for the repose-valve container to allow for slf4j to replicate the functionality of the http-logging filter.  
- Allow for more configuration around syslog facilities and what should be sent to syslog.  
- Allowing for different appenders for the local files to allow for size rotation as well as being able to use the NullAppender instead of the current DailyRollingFileAppender
