### PR TITLE
Fixing log4j maxFileSize

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.1.0'
+version '1.1.1'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -82,7 +82,7 @@
 #
 # [*log_local_size*]
 # String. The max file size for the log4j RollingFileAppender.
-# Defaults to <tt>100M</tt>
+# Defaults to <tt>100MB</tt>
 #
 # [*log_local_rotation_count*]
 # Integer. The number of backup files to keeo for the log4j RollingFileAppender

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -157,7 +157,7 @@ class repose::params {
   $log_local_policy = 'date'
 
 ## default local log size
-  $log_local_size = '100M'
+  $log_local_size = '100MB'
 
 ## default local log rotation count
   $log_local_rotation_count = 4

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.1.0
+Version:   1.1.1
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Wed Oct 01 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.1.1-1
+- fixing log_local_size to be MB not M
 * Mon Sep 29 2014 Greg Swift <greg.swift@rackspace.com> - 1.1.0-1
 - Add support for running on https port
 * Tue Sep 15 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.0.7-1

--- a/spec/classes/filter/container_spec.rb
+++ b/spec/classes/filter/container_spec.rb
@@ -132,7 +132,7 @@ describe 'repose::filter::container' do
       let(:params) { {
         :app_name                 => 'app',
         :log_local_policy         => 'size',
-        :log_local_size           => '50M',
+        :log_local_size           => '50MB',
         :log_local_rotation_count => 2,
         :log_access_local_name    => 'repose_access'
       } }
@@ -140,7 +140,7 @@ describe 'repose::filter::container' do
         should contain_file('/etc/repose/log4j.properties').
           with_content(/log4j\.logger\.http=INFO, httpLocal/).
           with_content(/httpLocal=org\.apache\.log4j\.RollingFileAppender/).
-          with_content(/httpLocal\.maxFileSize=50M/).
+          with_content(/httpLocal\.maxFileSize=50MB/).
           with_content(/httpLocal\.maxBackupIndex=2/).
           with_content(/httpLocal.File=\/var\/log\/repose\/repose_access\.log/)
         should contain_file('/etc/repose/container.cfg.xml')


### PR DESCRIPTION
The proper size denomination includes the B. 100M results in an exception being throw in stderr.log and weird results.
