### PR TITLE
Allow for configuration of the syslog facility

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.3.2'
+version '1.3.3'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.3.2
+Version:   1.3.3
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Thu Nov 13 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.3.3-1
+- Actually allow facility configuration for syslog
 * Tue Nov 04 2014 Alex Schultz <alex.schultz@rackspace.com> - 1.3.2-1
 - Adding rackspace-identity-basic-auth filter
 * Tue Nov 04 2014 Chad Wilson <chad.wilson@rackspace.com> - 1.3.1-1

--- a/spec/classes/filter/container_spec.rb
+++ b/spec/classes/filter/container_spec.rb
@@ -181,6 +181,7 @@ describe 'repose::filter::container' do
           with_content(/httpSyslog.syslogHost=syslog.example.com/).
           with_content(/httpSyslog.port=515/).
           with_content(/httpSyslog.protocol=tcp/).
+          with_content(/log4j.appender.httpSyslog.Facility=local1/).
           without_content(/log4j.appender.httpLocal.layout=org.apache.log4j.PatternLayout/)
         should contain_file('/etc/repose/container.cfg.xml')
       }
@@ -207,7 +208,34 @@ describe 'repose::filter::container' do
           without_content(/httpSyslog.syslogHost=syslog.example.com/).
           without_content(/httpSyslog.port=515/).
           without_content(/httpSyslog.protocol=tcp/).
-          with_content(/httpLocal.File=\/mypath\/http_repose.log/)
+          with_content(/httpLocal.File=\/mypath\/http_repose.log/).
+          with_content(/log4j.appender.syslog.Facility=local0/)
+        should contain_file('/etc/repose/container.cfg.xml')
+      }
+    end
+
+    context 'configure syslog facilities' do
+      let(:params) { {
+        :app_name            => 'app',
+        :log_dir             => '/mypath',
+        :log_level           => 'DEBUG',
+        :syslog_server       => 'syslog.example.com',
+        :log_access_syslog   => true,
+        :log_access_facility => 'local3',
+        :log_repose_facility => 'local4'
+      } }
+      it {
+        should contain_file('/etc/repose/log4j.properties').
+          with_content(/log4j\.appender\.defaultFile\.File=\/mypath\/app\.log/).
+          with_content(/log4j\.rootLogger=DEBUG, syslog, defaultFile/).
+          with_content(/syslog.syslogHost=syslog.example.com/).
+          with_content(/syslog.port=514/).
+          with_content(/log4j.logger.http=INFO, httpSyslog, httpLocal/).
+          with_content(/httpSyslog.syslogHost=syslog.example.com/).
+          with_content(/httpSyslog.port=514/).
+          with_content(/httpLocal.File=\/mypath\/http_repose.log/).
+          with_content(/log4j.appender.syslog.Facility=local4/).
+          with_content(/log4j.appender.httpSyslog.Facility=local3/)
         should contain_file('/etc/repose/container.cfg.xml')
       }
     end

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -35,7 +35,7 @@ log4j.appender.defaultFile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-4r
 
 <%- if @syslog_server -%>
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
-log4j.appender.syslog.Facility=local0
+log4j.appender.syslog.Facility=<%= @log_repose_facility %>
 log4j.appender.syslog.FacilityPrinting=false
 log4j.appender.syslog.Header=true
 log4j.appender.syslog.Threshold=<%= @log_level %>
@@ -61,7 +61,7 @@ log4j.logger.http=INFO, <%= httpAppenders.join(", ") %>
 log4j.additivity.http=false
 <%- if @log_access_syslog and @syslog_server %>
 log4j.appender.httpSyslog=org.apache.log4j.net.SyslogAppender
-log4j.appender.httpSyslog.Facility=local1
+log4j.appender.httpSyslog.Facility=<%= @log_access_facility %>
 log4j.appender.httpSyslog.FacilityPrinting=false
 log4j.appender.httpSyslog.Header=true
 log4j.appender.httpSyslog.syslogHost=<%= @syslog_server %>


### PR DESCRIPTION
Updating log4j configuration to actually use the facilities that are being passed into the repose::filter::container class.
