### PR TITLE
add attribute send_all_tenant_ids to class client_auth_n

### DIFF
--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -47,6 +47,10 @@
 # pool service is used.
 # Defaults to <tt>undef</tt>
 #
+# [*send_all_tenant_ids*]
+# Bool. Set to true to receive a list of all tenant ids associated with a token from identity.
+# Defaults to false
+#
 # === Links
 #
 # * http://wiki.openrepose.org/display/REPOSE/Client+Authentication+Filter
@@ -82,6 +86,7 @@ define repose::filter::client_auth_n (
   $token_cache_timeout = undef,
   $group_cache_timeout = '60000',
   $connection_pool_id  = undef,
+  $send_all_tenant_ids = false,
 ) {
 
 ### Validate parameters

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -134,5 +134,29 @@ describe 'repose::filter::client_auth_n', :type => :define do
       }
     end
 
+    context 'providing send_all_tenant_ids' do
+      let(:title) { 'default' }
+      let(:params) { {
+          :ensure              => 'present',
+          :filename            => 'client-auth-n.cfg.xml',
+          :auth                => {
+              'user' => 'username',
+              'pass' => 'password',
+              'uri'  => 'http://uri'
+          },
+          :send_all_tenant_ids => true,
+      } }
+      it {
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').with(
+                   :ensure => 'file',
+                   :owner => 'repose',
+                   :group => 'repose'
+               )
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').
+                   with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
+                   with_content(/send-all-tenant-ids=\"true\"/)
+      }
+    end
+
   end
 end

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
-    <openstack-auth delegable="<%= @delegable %>" tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+    <openstack-auth delegable="<%= @delegable %>" tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> send-all-tenant-ids="<%= @send_all_tenant_ids %>" xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
         <identity-service username="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>" uri="<%= @auth['uri'] -%>" />
 <%- if @client_maps -%>
   <% @client_maps.each do |client_map| -%>


### PR DESCRIPTION
and add attribute send-all-tenant-ids to openstack-auth node in client-auth-n.cfg.xml;
default to false so no change in default behavior of the repose auth call to identity,
but will allow cloudfeeds to set it to true to retrieve all client IDs when retrieving the token.
