### PR TITLE
DNM: Updating package names for repose 6.2.x and up

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,7 +1,0 @@
-name 'citops-repose'
-version '1.3.5'
-description "Repose is an api middleware that provides authentication,
-filtering, ratelimitting and several other features, this deploys it."
-project_page 'https://github.com/rackerlabs/puppet-repose'
-
-dependency 'puppetlabs/stdlib', '>= 2.0.0'

--- a/README.rdoc
+++ b/README.rdoc
@@ -79,18 +79,29 @@ This module provides a re-usable and environment agnostic control of Repose Powe
 
 ---
 == Running tests with bundler
-  git clone http://github.com/rackerlabs/puppet-repose.git 
+  git clone http://github.com/rackerlabs/puppet-repose.git
   cd puppet-repose
   bundle install
   bundle exec rake validate
   bundle exec rake spec
 
 == Running tests
-  git clone http://github.com/rackerlabs/puppet-repose.git 
+  git clone http://github.com/rackerlabs/puppet-repose.git
   cd puppet-repose
   gem install rspec-puppet rspec-puppet-utils puppet puppetlabs_spec_helper --no-ri --no-rdoc
   rake validate
   rake spec
+
+
+
+---
+== Puppet Module Version Considerations
+
+The puppet module version < 2.0 supports repose < 6.2.x.  There was a package
+name change for rpms that makes the 2.x and greater modules incompatibile with
+the older versions of repose. If you need to configure repose < 6.2.x, please
+use the older module version (< 2.0).
+
 
 ---
 ==Authors

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,7 +62,7 @@ class repose::params {
 
 ## packages
   $packages = $::osfamily ? {
-    /(RedHat|Debian)/ => [ 'repose-filters','repose-extension-filters' ],
+    /(RedHat|Debian)/ => [ 'repose-filter-bundle','repose-extensions-filter-bundle' ],
   }
 
 ## tomcat7_package

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "citops-repose",
+  "version": "2.0.0",
+  "author": "citops",
+  "summary": "Puppet module to manage Repose software",
+  "license": "Apache-2.0",
+  "source": "https://github.com/rackerlabs/puppet-repose.git",
+  "project_page": "https://github.com/rackerlabs/puppet-repose",
+  "issues_url": "https://github.com/rackerlabs/puppet-repose/issues",
+  "description": "Repose is an api middleware that provides authentication,filtering, ratelimitting and several other features, this deploys it.",
+  "dependencies": [
+    {"version_requirement":">= 2.0.0","name":"puppetlabs/stdlib"}
+  ]
+}

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.3.6
+Version:   2.0.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Tue Mar 03 2015 Alex Schultz <alex.schultz@rackspace.com> - 2.0.0-1
+- BREAKING CHANGE: Changing package names on RHEL/CentOS for repose >= 6.2.0
 * Tue Jan 20 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.3.6-1
 - Adding configuration for travis-ci
 * Mon Jan 05 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.3.5-1

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -8,13 +8,24 @@ describe 'repose::package' do
     }
     end
 
+    let(:pkg_names) {
+      [
+        'repose-valve',
+        'repose-filter-bundle',
+        'repose-extensions-filter-bundle'
+      ]
+    }
+
     # the defaults for the package class should
     # 1) install the package
     context 'with defaults for all parameters' do
       it {
+        pkg_names.each do |pkg|
+          should contain_package(pkg).with_ensure('present')
+        end
         should contain_package('repose-valve').with_ensure('present')
-        should contain_package('repose-filters').with_ensure('present')
-        should contain_package('repose-extension-filters').with_ensure('present')
+        should contain_package('repose-filter-bundle').with_ensure('present')
+        should contain_package('repose-extensions-filter-bundle').with_ensure('present')
       }
     end
 
@@ -22,12 +33,12 @@ describe 'repose::package' do
     # 1) install the package to a specific version
     context 'with package version' do
       let(:params) { {
-        :ensure => '6.1.1.1'
+        :ensure => '7.0.0.1'
       } }
       it {
-        should contain_package('repose-valve').with_ensure('6.1.1.1')
-        should contain_package('repose-filters').with_ensure('6.1.1.1')
-        should contain_package('repose-extension-filters').with_ensure('6.1.1.1')
+        pkg_names.each do |pkg|
+          should contain_package(pkg).with_ensure(params[:ensure])
+        end
       }
     end
 
@@ -38,9 +49,9 @@ describe 'repose::package' do
         :autoupgrade => true
       } }
       it {
-        should contain_package('repose-valve').with_ensure('latest')
-        should contain_package('repose-filters').with_ensure('latest')
-        should contain_package('repose-extension-filters').with_ensure('latest')
+        pkg_names.each do |pkg|
+          should contain_package(pkg).with_ensure('latest')
+        end
       }
     end
 
@@ -48,9 +59,9 @@ describe 'repose::package' do
     context 'uninstall parameters' do
       let(:params) { { :ensure => 'absent' } }
       it {
-        should contain_package('repose-valve').with_ensure('purged')
-        should contain_package('repose-filters').with_ensure('purged')
-        should contain_package('repose-extension-filters').with_ensure('purged')
+        pkg_names.each do |pkg|
+          should contain_package(pkg).with_ensure('purged')
+        end
       }
     end
   end


### PR DESCRIPTION
With repose 6.2.0.x, the rpm packages have been named from repose-filters and repose-extention-filters to repose-filter-bundle and repose-extentions-filter-bundle. This pull request includes this package name change as well as incrementing the version to indicate the breaking change.

DO NOT MERGE YET: need additional log4j config updates as well for  repose 7+