### PR TITLE
Update for new naming - supports both version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,10 @@
 #
 # === Parameters
 #
+# The default values for the parameters are set in repose::params. Have
+# a look at the corresponding <tt>params.pp</tt> manifest file if you need more
+# technical information about them.
+#
 # [*ensure*]
 # String. Controls if the managed resources shall be <tt>present</tt>,
 # <tt>absent</tt>, <tt>latest</tt> or a version nuymber. If set to
@@ -36,10 +40,12 @@
 # * {Puppet's package provider source code}[http://j.mp/wtVCaL]
 # Defaults to <tt>false</tt>.
 #
-# The default values for the parameters are set in repose::params. Have
-# a look at the corresponding <tt>params.pp</tt> manifest file if you need more
-# technical information about them.
-#
+# [*use_old_packages*]
+# Boolean. At version 6.2 repose renamed several of their packages to
+# standardize between deb/rpm.  This variable exposes access to the old
+# naming. It defaults to <tt>true</tt> for the time being to not break
+# existing users.
+# TODO: Determine a time to default to false. Then when to drop support.
 #
 # === Examples
 #
@@ -58,10 +64,11 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose (
-  $ensure      = $repose::params::ensure,
-  $enable      = $repose::params::enable,
-  $container   = $repose::params::container,
-  $autoupgrade = $repose::params::autoupgrade,
+  $ensure           = $repose::params::ensure,
+  $enable           = $repose::params::enable,
+  $container        = $repose::params::container,
+  $autoupgrade      = $repose::params::autoupgrade,
+  $use_old_packages = true,
 ) inherits repose::params {
 
 ### Validate parameters
@@ -119,9 +126,10 @@ class repose (
 
 ## package(s)
   class { 'repose::package':
-    ensure      => $ensure,
-    autoupgrade => $autoupgrade,
-    container   => $container
+    ensure           => $ensure,
+    autoupgrade      => $autoupgrade,
+    container        => $container,
+    use_old_packages => $use_old_packages,
   }
 
 ## service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,11 +40,11 @@
 # * {Puppet's package provider source code}[http://j.mp/wtVCaL]
 # Defaults to <tt>false</tt>.
 #
-# [*use_old_packages*]
+# [*rh_old_packages*]
 # Boolean. At version 6.2 repose renamed several of their packages to
 # standardize between deb/rpm.  This variable exposes access to the old
-# naming. It defaults to <tt>true</tt> for the time being to not break
-# existing users.
+# naming on rpm distros. It defaults to <tt>true</tt> for the time being
+# to not break existing users.
 # TODO: Determine a time to default to false. Then when to drop support.
 #
 # === Examples
@@ -68,7 +68,7 @@ class repose (
   $enable           = $repose::params::enable,
   $container        = $repose::params::container,
   $autoupgrade      = $repose::params::autoupgrade,
-  $use_old_packages = true,
+  $rh_old_packages  = true,
 ) inherits repose::params {
 
 ### Validate parameters
@@ -129,7 +129,7 @@ class repose (
     ensure           => $ensure,
     autoupgrade      => $autoupgrade,
     container        => $container,
-    use_old_packages => $use_old_packages,
+    rh_old_packages  => $rh_old_packages,
   }
 
 ## service

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,6 +34,12 @@
 # The package list to use based on the container that is used to run
 # repose in this environment
 #
+# [*use_old_packages*]
+# Boolean. At version 6.2 repose renamed several of their packages to
+# standardize between deb/rpm.  This variable exposes access to the old
+# naming. It defaults to True for the time being to not break existing
+# users.
+#
 # === Examples
 #
 # Primarily to be used by the repose base class, but you can use:
@@ -48,9 +54,10 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose::package (
-  $ensure      = $repose::params::ensure,
-  $autoupgrade = $repose::params::autoupgrade,
-  $container   = $repose::params::container,
+  $ensure           = $repose::params::ensure,
+  $autoupgrade      = $repose::params::autoupgrade,
+  $container        = $repose::params::container,
+  $use_old_packages = true,
 ) inherits repose::params {
 
 ### Logic
@@ -88,7 +95,12 @@ class repose::package (
     before => $before,
   }
 
-  package { $repose::params::packages:
+  $filter_packages = $use_old_packages ? {
+    true    => $repose::params::old_packages,
+    default => $repose::params::packages,
+  }
+
+  package { $filter_packages:
     ensure  => $package_ensure,
     require => Package[$container_package],
   }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,11 +34,11 @@
 # The package list to use based on the container that is used to run
 # repose in this environment
 #
-# [*use_old_packages*]
+# [*rh_old_packages*]
 # Boolean. At version 6.2 repose renamed several of their packages to
 # standardize between deb/rpm.  This variable exposes access to the old
-# naming. It defaults to True for the time being to not break existing
-# users.
+# naming on rpm distros. It defaults to <tt>true</tt> for the time being
+# to not break existing users.
 #
 # === Examples
 #
@@ -57,7 +57,7 @@ class repose::package (
   $ensure           = $repose::params::ensure,
   $autoupgrade      = $repose::params::autoupgrade,
   $container        = $repose::params::container,
-  $use_old_packages = true,
+  $rh_old_packages  = true,
 ) inherits repose::params {
 
 ### Logic
@@ -95,7 +95,7 @@ class repose::package (
     before => $before,
   }
 
-  $filter_packages = $use_old_packages ? {
+  $filter_packages = $rh_old_packages ? {
     true    => $repose::params::old_packages,
     default => $repose::params::packages,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,8 +61,12 @@ class repose::params {
   }
 
 ## packages
-  $packages = $::osfamily ? {
+  $old_packages = $::osfamily ? {
     /(RedHat|Debian)/ => [ 'repose-filters','repose-extension-filters' ],
+  }
+
+  $packages = $::osfamily ? {
+    /(RedHat|Debian)/ => [ 'repose-filter-bundle','repose-extension-filter-bundle' ],
   }
 
 ## tomcat7_package

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,12 +61,13 @@ class repose::params {
   }
 
 ## packages
-  $old_packages = $::osfamily ? {
-    /(RedHat|Debian)/ => [ 'repose-filters','repose-extension-filters' ],
-  }
-
   $packages = $::osfamily ? {
     /(RedHat|Debian)/ => [ 'repose-filter-bundle','repose-extension-filter-bundle' ],
+  }
+
+  $old_packages = $::osfamily ? {
+    /RedHat/ => [ 'repose-filters','repose-extension-filters' ],
+    /Debian/ => $packages,
   }
 
 ## tomcat7_package

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -36,6 +36,36 @@ describe 'repose' do
       }
     end
 
+    # Validating that the old package names will be used
+    context 'with specific version' do
+      let(:params) { { :use_old_packages => 'true' } }
+      it {
+        should contain_class('repose')
+        should contain_class('repose::package').with(
+          'use_old_packages' => 'true')
+        should contain_class('repose::service').with_ensure('present')
+        should contain_file('/etc/security/limits.d/repose').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose')
+      }
+    end
+
+    # Validating that the new package names will be used
+    context 'with specific version' do
+      let(:params) { { :use_old_packages => 'false' } }
+      it {
+        should contain_class('repose')
+        should contain_class('repose::package').with(
+          'use_old_packages' => 'false')
+        should contain_class('repose::service').with_ensure('present')
+        should contain_file('/etc/security/limits.d/repose').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose')
+      }
+    end
+
     # Validate uninstall properly passes ensure = absent around
     context 'uninstall parameters' do
       let(:params) { { :ensure => 'absent' } }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -38,11 +38,11 @@ describe 'repose' do
 
     # Validating that the old package names will be used
     context 'with specific version' do
-      let(:params) { { :use_old_packages => 'true' } }
+      let(:params) { { :rh_old_packages => 'true' } }
       it {
         should contain_class('repose')
         should contain_class('repose::package').with(
-          'use_old_packages' => 'true')
+          'rh_old_packages' => 'true')
         should contain_class('repose::service').with_ensure('present')
         should contain_file('/etc/security/limits.d/repose').with(
           'ensure' => 'file',
@@ -53,11 +53,11 @@ describe 'repose' do
 
     # Validating that the new package names will be used
     context 'with specific version' do
-      let(:params) { { :use_old_packages => 'false' } }
+      let(:params) { { :rh_old_packages => 'false' } }
       it {
         should contain_class('repose')
         should contain_class('repose::package').with(
-          'use_old_packages' => 'false')
+          'rh_old_packages' => 'false')
         should contain_class('repose::service').with_ensure('present')
         should contain_file('/etc/security/limits.d/repose').with(
           'ensure' => 'file',

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -57,7 +57,7 @@ describe 'repose::package' do
     # the defaults for the package class should
     # 1) install the package
     context 'with defaults+newpackages for all parameters' do
-      let(:params) { { :use_old_packages => 'false' } }
+      let(:params) { { :rh_old_packages => 'false' } }
       it {
         should contain_package('repose-valve').with_ensure('present')
         should contain_package('repose-filter-bundle').with_ensure('present')
@@ -69,8 +69,8 @@ describe 'repose::package' do
     # 1) install the package to a specific version
     context 'with package version+newpackages' do
       let(:params) { {
-        :ensure           => '6.2.0.1',
-        :use_old_packages => 'false'
+        :ensure          => '6.2.0.1',
+        :rh_old_packages => 'false'
       } }
       it {
         should contain_package('repose-valve').with_ensure('6.2.0.1')
@@ -83,8 +83,8 @@ describe 'repose::package' do
     # 1) set the packages to latest
     context 'with autoupgrade true' do
       let(:params) { {
-        :autoupgrade      => true,
-        :use_old_packages => 'false'
+        :autoupgrade     => true,
+        :rh_old_packages => 'false'
       } }
       it {
         should contain_package('repose-valve').with_ensure('latest')
@@ -96,8 +96,8 @@ describe 'repose::package' do
     # Validate uninstall properly purged packages
     context 'uninstall parameters' do
       let(:params) { {
-        :ensure           => 'absent',
-        :use_old_packages => 'false'
+        :ensure          => 'absent',
+        :rh_old_packages => 'false'
       } }
       it {
         should contain_package('repose-valve').with_ensure('purged')

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -53,5 +53,57 @@ describe 'repose::package' do
         should contain_package('repose-extension-filters').with_ensure('purged')
       }
     end
+
+    # the defaults for the package class should
+    # 1) install the package
+    context 'with defaults+newpackages for all parameters' do
+      let(:params) { { :use_old_packages => 'false' } }
+      it {
+        should contain_package('repose-valve').with_ensure('present')
+        should contain_package('repose-filter-bundle').with_ensure('present')
+        should contain_package('repose-extension-filter-bundle').with_ensure('present')
+      }
+    end
+
+    # specifying a version for the package class should
+    # 1) install the package to a specific version
+    context 'with package version+newpackages' do
+      let(:params) { {
+        :ensure           => '6.2.0.1',
+        :use_old_packages => 'false'
+      } }
+      it {
+        should contain_package('repose-valve').with_ensure('6.2.0.1')
+        should contain_package('repose-filter-bundle').with_ensure('6.2.0.1')
+        should contain_package('repose-extension-filter-bundle').with_ensure('6.2.0.1')
+      }
+    end
+
+    # specifying autoupgrade is true for the package class should
+    # 1) set the packages to latest
+    context 'with autoupgrade true' do
+      let(:params) { {
+        :autoupgrade      => true,
+        :use_old_packages => 'false'
+      } }
+      it {
+        should contain_package('repose-valve').with_ensure('latest')
+        should contain_package('repose-filter-bundle').with_ensure('latest')
+        should contain_package('repose-extension-filter-bundle').with_ensure('latest')
+      }
+    end
+
+    # Validate uninstall properly purged packages
+    context 'uninstall parameters' do
+      let(:params) { {
+        :ensure           => 'absent',
+        :use_old_packages => 'false'
+      } }
+      it {
+        should contain_package('repose-valve').with_ensure('purged')
+        should contain_package('repose-filter-bundle').with_ensure('purged')
+        should contain_package('repose-extension-filter-bundle').with_ensure('purged')
+      }
+    end
   end
 end


### PR DESCRIPTION
As of v6.2 series of Repose the packages were renamed.  This PR supports the new names by making the option a parameter. This provides for a migration path, and continued support for slightly olde configs for at least a short time.

Its an alternative to #23 