### PR TITLE
Fixing tests to work with newer rspec-puppet

### DIFF
--- a/spec/classes/filter/container_spec.rb
+++ b/spec/classes/filter/container_spec.rb
@@ -10,9 +10,7 @@ describe 'repose::filter::container' do
 
     context 'with defaults for all parameters' do
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /app_name is a required parameter/)
+        should raise_error(Puppet::Error, /app_name is a required parameter/)
       }
     end
 

--- a/spec/classes/filter/http_connection_pool_spec.rb
+++ b/spec/classes/filter/http_connection_pool_spec.rb
@@ -5,7 +5,7 @@ describe 'repose::filter::http_connection_pool', :type => :class do
   end
 
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -43,7 +43,7 @@ describe 'repose::filter::http_connection_pool', :type => :class do
 
     context 'with additional pool' do
       let(:params) { {
-        :additional_pools => [ { 
+        :additional_pools => [ {
            "id"                           => 'client-auth-pool',
            "is_default"                   => false,
            "conn_manager_max_total"       => 201,

--- a/spec/classes/filter_spec.rb
+++ b/spec/classes/filter_spec.rb
@@ -3,9 +3,7 @@ describe 'repose::filter' do
 
   context 'with defaults for all parameters' do
     it do
-      expect {
-        should compile
-      }.to raise_error(Puppet::Error, /This class should not be used directly/)
+      should raise_error(Puppet::Error, /This class should not be used directly/)
     end
   end
 end

--- a/spec/classes/logrotate_spec.rb
+++ b/spec/classes/logrotate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'repose::logrotate' do
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -14,7 +14,7 @@ describe 'repose::logrotate' do
     # 3) keep 4 files
     # 4) compress, delaycompress, dateext are enabled
     context 'with defaults for all parameters' do
-      it { 
+      it {
         should contain_file('/etc/logrotate.d/repose').with(
           'ensure' => 'file',
           'owner'  => 'root',
@@ -30,7 +30,7 @@ describe 'repose::logrotate' do
     end
 
     context 'configure params parameters' do
-      let(:params) { { 
+      let(:params) { {
         :log_files        => [ '/repose1.log', '/repose2.log' ],
         :rotate_frequency => 'weekly',
         :rotate_count     => 10,

--- a/spec/classes/tomcat7_spec.rb
+++ b/spec/classes/tomcat7_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'repose::tomcat7' do
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -9,7 +9,7 @@ describe 'repose::tomcat7' do
     end
 
     context 'with defaults for all parameters' do
-      it { 
+      it {
         should contain_class('repose').with(
           'ensure'      => 'present',
           'enable'      => 'true',

--- a/spec/defines/filter/api_validator_spec.rb
+++ b/spec/defines/filter/api_validator_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::api_validator', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::api_validator', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /validators is a required list/)
+        should raise_error(Puppet::Error,/validators is a required list/)
       }
     end
 
@@ -34,7 +32,7 @@ describe 'repose::filter::api_validator', :type => :define do
 
     context 'providing a validator' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'test-validator.cfg.xml',
         :validators => [ {
@@ -58,7 +56,7 @@ describe 'repose::filter::api_validator', :type => :define do
         }, ],
         :multi_role_match => true,
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/test-validator.cfg.xml')
         should contain_file('/etc/repose/test-validator.cfg.xml').
           with_content(/multi-role-match="true"/).

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -15,9 +15,7 @@ describe 'repose::filter::client_auth_n', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /auth is a required parameter/)
+        should raise_error(Puppet::Error, /auth is a required parameter/)
       }
     end
 

--- a/spec/defines/filter/compression_spec.rb
+++ b/spec/defines/filter/compression_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::compression', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',

--- a/spec/defines/filter/content_normalization_spec.rb
+++ b/spec/defines/filter/content_normalization_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::content_normalization', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',

--- a/spec/defines/filter/dist_datastore_spec.rb
+++ b/spec/defines/filter/dist_datastore_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::dist_datastore', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::dist_datastore', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /nodes is a required parameter/)
+        should raise_error(Puppet::Error,/nodes is a required parameter/)
       }
     end
 
@@ -34,12 +32,12 @@ describe 'repose::filter::dist_datastore', :type => :define do
 
     context 'providing a validator' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'dist-datastore.cfg.xml',
         :nodes      => [ 'test.example.com', ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/dist-datastore.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/header_translation_spec.rb
+++ b/spec/defines/filter/header_translation_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::header_translation', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -36,7 +36,7 @@ describe 'repose::filter::header_translation', :type => :define do
 
     context 'providing a translations map' do
       let(:title) { 'header_translations' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'header-translation.cfg.xml',
         :header_translations => [ {
@@ -45,7 +45,7 @@ describe 'repose::filter::header_translation', :type => :define do
           'remove_original' => 'true'
         } ]
       } }
-      it { 
+      it {
         # <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<header-translation xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n xsi:schemaLocation=\"http://docs.api.rackspacecloud.com/repose/header-translation/v1.0 ../config/header-translation.xsd\"\n xmlns=\"http://docs.api.rackspacecloud.com/repose/header-translation/v1.0\">\n\n    <header original-name=\"orig\" new-name=\"new\" remove-original=\"true\" />\n\n</header_translation>\n
         should contain_file('/etc/repose/header-translation.cfg.xml').with_content(
           /<header original-name=\"orig\" new-name=\"new\" remove-original=\"true\" \/>/

--- a/spec/defines/filter/http_logging_spec.rb
+++ b/spec/defines/filter/http_logging_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::http_logging', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::http_logging', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /log_files is a required parameter/)
+        should raise_error(Puppet::Error, /log_files is a required parameter/)
       }
     end
 
@@ -34,16 +32,16 @@ describe 'repose::filter::http_logging', :type => :define do
 
     context 'providing a log_file' do
       let(:title) { 'log_file' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'http-logging.cfg.xml',
-        :log_files  => [ { 
-          'id'       => 'my-log', 
+        :log_files  => [ {
+          'id'       => 'my-log',
           'format'   => 'my format',
           'location' => '/var/log/repose/http.log'
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/http-logging.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/ip_identity_spec.rb
+++ b/spec/defines/filter/ip_identity_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::ip_identity', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::ip_identity', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /whitelist is a required parameters/)
+        should raise_error(Puppet::Error,/whitelist is a required parameter/)
       }
     end
 
@@ -34,7 +32,7 @@ describe 'repose::filter::ip_identity', :type => :define do
 
     context 'providing a whitelist' do
       let(:title) { 'whitelist' }
-      let(:params) { { 
+      let(:params) { {
         :ensure    => 'present',
         :filename  => 'ip-identity.cfg.xml',
         :quality   => '0.25',
@@ -43,7 +41,7 @@ describe 'repose::filter::ip_identity', :type => :define do
           'addresses' => [ '9.9.9.9', ],
         }
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/ip-identity.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/metrics_spec.rb
+++ b/spec/defines/filter/metrics_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::metrics', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::metrics', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /graphite_servers is a required/)
+        should raise_error(Puppet::Error, /graphite_servers is a required/)
       }
     end
 
@@ -34,7 +32,7 @@ describe 'repose::filter::metrics', :type => :define do
 
     context 'providing a graphite server' do
       let(:title) { 'graphite_server' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'metrics.cfg.xml',
         :graphite_servers => [ {
@@ -45,7 +43,7 @@ describe 'repose::filter::metrics', :type => :define do
           'enabled' => 'true'
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/metrics.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/rackspace_identity_basic_auth_spec.rb
+++ b/spec/defines/filter/rackspace_identity_basic_auth_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::rackspace_identity_basic_auth', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -33,23 +33,23 @@ describe 'repose::filter::rackspace_identity_basic_auth', :type => :define do
     end
     context 'providing a validator' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'my-config.cfg.xml',
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/my-config.cfg.xml')
       }
     end
 
     context 'lowering token cache' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure              => 'present',
         :filename            => 'rackspace-identity-basic-auth.cfg.xml',
         :token_cache_timeout => '1000'
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/rackspace-identity-basic-auth.cfg.xml').with_content(/token-cache-timeout-millis="1000"/)
       }
     end

--- a/spec/defines/filter/rate_limiting_spec.rb
+++ b/spec/defines/filter/rate_limiting_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::rate_limiting', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,48 +15,42 @@ describe 'repose::filter::rate_limiting', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /request_endpoint is a required/)
+        should raise_error(Puppet::Error, /request_endpoint is a required/)
       }
     end
 
     context 'only provide request_endpoint' do
       let(:title) { 'request_endpoint' }
-      let(:params) { { 
+      let(:params) { {
         :request_endpoint => {
           'uri-regex'              => '/limits/stuff/?',
           'include_absolut_limits' => 'false'
-        } 
+        }
       } }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /limit_groups is a required/)
+        should raise_error(Puppet::Error, /limit_groups is a required/)
       }
     end
 
     context 'only provide limit_groups' do
       let(:title) { 'limit_groups' }
-      let(:params) { { 
+      let(:params) { {
         :limit_groups => [ {
           'id'        => 'Some_Group',
           'groups'    => 'Some_Group',
           'default'   => true,
           'limits'    => [
-          { 
+          {
             'uri'          => '/.*',
             'uri_regex'    => '/.*',
             'http_methods' => 'GET',
             'unit'         => 'SECOND',
-            'value'        => '200' 
+            'value'        => '200'
           }, ],
         } ]
       } }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /request_endpoint is a required/)
+        should raise_error(Puppet::Error, /request_endpoint is a required/)
       }
     end
 
@@ -73,7 +67,7 @@ describe 'repose::filter::rate_limiting', :type => :define do
 
     context 'providing parameters' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'rate-limiting.cfg.xml',
         :request_endpoint => {
@@ -85,18 +79,18 @@ describe 'repose::filter::rate_limiting', :type => :define do
           'groups'    => 'Some_Group',
           'default'   => true,
           'limits'    => [
-          { 
+          {
             'id'           => 'some_limit_id',
             'uri'          => '/.*',
             'uri_regex'    => '/.*',
             'http_methods' => 'GET',
             'unit'         => 'SECOND',
-            'value'        => '200' 
+            'value'        => '200'
           },
           ]
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/rate-limiting.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',
@@ -111,7 +105,7 @@ describe 'repose::filter::rate_limiting', :type => :define do
 
     context 'providing parameters, skipping limit id for repose < 5.0.0' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'rate-limiting.cfg.xml',
         :request_endpoint => {
@@ -123,17 +117,17 @@ describe 'repose::filter::rate_limiting', :type => :define do
           'groups'    => 'Some_Group',
           'default'   => true,
           'limits'    => [
-          { 
+          {
             'uri'          => '/.*',
             'uri_regex'    => '/.*',
             'http_methods' => 'GET',
             'unit'         => 'SECOND',
-            'value'        => '200' 
+            'value'        => '200'
           },
           ]
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/rate-limiting.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',
@@ -149,7 +143,7 @@ describe 'repose::filter::rate_limiting', :type => :define do
 
     context 'providing overlimit' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'rate-limiting.cfg.xml',
         :request_endpoint => {
@@ -162,17 +156,17 @@ describe 'repose::filter::rate_limiting', :type => :define do
           'groups'    => 'Some_Group',
           'default'   => true,
           'limits'    => [
-          { 
+          {
             'uri'          => '/.*',
             'uri_regex'    => '/.*',
             'http_methods' => 'GET',
             'unit'         => 'SECOND',
-            'value'        => '200' 
+            'value'        => '200'
           },
           ]
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/rate-limiting.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/response_messaging_spec.rb
+++ b/spec/defines/filter/response_messaging_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::response_messaging', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::response_messaging', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /status_codes is a required/)
+        should raise_error(Puppet::Error, /status_codes is a required/)
       }
     end
 
@@ -34,7 +32,7 @@ describe 'repose::filter::response_messaging', :type => :define do
 
     context 'providing status_codes' do
       let(:title) { 'status_codes' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'response-messaging.cfg.xml',
         :status_codes  => [
@@ -49,7 +47,7 @@ describe 'repose::filter::response_messaging', :type => :define do
           ]
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/response-messaging.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/slf4j_http_logging_spec.rb
+++ b/spec/defines/filter/slf4j_http_logging_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::slf4j_http_logging', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::slf4j_http_logging', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /log_files is a required/)
+        should raise_error(Puppet::Error, /log_files is a required/)
       }
     end
 
@@ -34,15 +32,15 @@ describe 'repose::filter::slf4j_http_logging', :type => :define do
 
     context 'providing log_files' do
       let(:title) { 'log_files' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'slf4j-http-logging.cfg.xml',
-        :log_files  => [ { 
-          'id'       => 'my-log', 
+        :log_files  => [ {
+          'id'       => 'my-log',
           'format'   => 'my format',
         } ]
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/slf4j-http-logging.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -15,9 +15,7 @@ describe 'repose::filter::system_model', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /nodes is a required/)
+        should raise_error(Puppet::Error, /nodes is a required/)
       }
     end
 
@@ -27,9 +25,7 @@ describe 'repose::filter::system_model', :type => :define do
         :app_name => 'repose'
       } }
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /nodes is a required/)
+        should raise_error(Puppet::Error, /nodes is a required/)
       }
     end
 
@@ -40,9 +36,7 @@ describe 'repose::filter::system_model', :type => :define do
         :nodes    => ['app1', 'app2' ],
       } }
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /filters is a required/)
+        should raise_error(Puppet::Error, /filters is a required/)
       }
     end
 
@@ -65,9 +59,7 @@ describe 'repose::filter::system_model', :type => :define do
         }
       } }
       it {
-        expect {
-          should compile
-        }.to raise_error(Puppet::Error, /endpoints is a required/)
+        should raise_error(Puppet::Error, /endpoints is a required/)
       }
     end
 

--- a/spec/defines/filter/template.rb
+++ b/spec/defines/filter/template.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::CHANGEME', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::CHANGEME', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /is a required/)
+        should raise_error(Puppet::Error, /is a required/)
       }
     end
 
@@ -33,11 +31,11 @@ describe 'repose::filter::CHANGEME', :type => :define do
     end
     context 'providing a validator' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'CHANGEME.cfg.xml',
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/CHANGEME.cfg.xml')
       }
     end

--- a/spec/defines/filter/translation_spec.rb
+++ b/spec/defines/filter/translation_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::translation', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -39,7 +39,7 @@ describe 'repose::filter::translation', :type => :define do
 
     context 'providing parameters' do
       let(:title) { 'validator' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'translation.cfg.xml',
         :response_translations => [
@@ -58,7 +58,7 @@ describe 'repose::filter::translation', :type => :define do
         ],
         :xsl_engine => 'SaxonEE'
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/translation.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',

--- a/spec/defines/filter/versioning_spec.rb
+++ b/spec/defines/filter/versioning_spec.rb
@@ -4,7 +4,7 @@ describe 'repose::filter::versioning', :type => :define do
     'include repose'
   end
   context 'on RedHat' do
-    let :facts do 
+    let :facts do
     {
       :osfamily               => 'RedHat',
       :operationsystemrelease => '6',
@@ -15,9 +15,7 @@ describe 'repose::filter::versioning', :type => :define do
     context 'default parameters' do
       let(:title) { 'default' }
       it {
-        expect { 
-          should compile
-        }.to raise_error(Puppet::Error, /target_uri is a required/)
+        should raise_error(Puppet::Error, /target_uri is a required/)
       }
     end
 
@@ -34,12 +32,12 @@ describe 'repose::filter::versioning', :type => :define do
 
     context 'providing target_uri' do
       let(:title) { 'target_uri' }
-      let(:params) { { 
+      let(:params) { {
         :ensure     => 'present',
         :filename   => 'versioning.cfg.xml',
         :target_uri => 'http://localhost/repose',
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/versioning.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',
@@ -51,7 +49,7 @@ describe 'repose::filter::versioning', :type => :define do
 
     context 'providing target_uri and version_mappings' do
       let(:title) { 'target_uri' }
-      let(:params) { { 
+      let(:params) { {
         :ensure           => 'present',
         :filename         => 'versioning.cfg.xml',
         :target_uri       => 'http://localhost/repose',
@@ -65,7 +63,7 @@ describe 'repose::filter::versioning', :type => :define do
           ]
         } ] ,
       } }
-      it { 
+      it {
         should contain_file('/etc/repose/versioning.cfg.xml').with(
           'ensure' => 'file',
           'owner'  => 'repose',


### PR DESCRIPTION
This PR fixes the failing tests from the catching for Puppet::Errors.  The format changed at some point, see https://github.com/rodjek/rspec-puppet/issues/232