### PR TITLE
DNM: Repose 7 support

### DIFF
--- a/.gemfiles/Gemfile.rspec
+++ b/.gemfiles/Gemfile.rspec
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 puppetversion = ENV['PUPPET_VERSION']
 gem 'puppet', puppetversion, :require => false
+gem 'rspec-core', '3.1.7'
 gem 'puppet-lint'
 gem 'rspec-puppet'
 gem 'rspec-puppet-utils'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development, :test do
   gem 'mime-types', '<2.0',      :require => false
   gem 'rake',  '10.1.1',         :require => false
   gem 'rspec-puppet',            :require => false
+  gem 'rspec-puppet-utils',      :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false

--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.3.5'
+version '1.4.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/api_validator.pp
+++ b/manifests/filter/api_validator.pp
@@ -106,7 +106,7 @@ define repose::filter::api_validator (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -25,8 +25,15 @@
 # Array containing roles to exclude from restrictions
 #
 # [*delegable*]
-# Bool.
+# DEPRECATED: Replaced with delegating in repose 7, defining
+# <tt>delegating</tt> will remove this from the configration.
+# Bool. Delegate the decision to authenticate a request down the chain to
+# either another filter or to the origin service.
 # Defaults to <tt>false</tt>
+#
+# [*delegating*]
+# Bool. This replaces delagable in repose 7+.
+# Defaults to <tt>undef</tt>
 #
 # [*tendanted*]
 # Bool.
@@ -82,6 +89,7 @@ define repose::filter::client_auth_n (
   $white_lists         = undef,
   $ignore_tenant_roles = undef,
   $delegable           = false,
+  $delegating          = undef,
   $tenanted            = false,
   $request_groups      = undef,
   $token_cache_timeout = undef,

--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -130,7 +130,7 @@ define repose::filter::client_auth_n (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/compression.pp
+++ b/manifests/filter/compression.pp
@@ -80,7 +80,7 @@ define repose::filter::compression (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -46,6 +46,11 @@
 # String. The facility to use when sending access logs via syslog.
 # Defaults to <tt>local1</tt>
 #
+# [*log_access_app_name*]
+# String. This is the app name to be sent to syslog as part of the RFC5424
+# message format. This defaults to blank.
+# Defaults to <tt></tt>.
+#
 # [*log_access_local*]
 # Boolean. Should repose access logs be logged locally. Uses the log_local_*
 # Settings to determine retention policy.
@@ -96,6 +101,9 @@
 # [*log_use_log4j2*]
 # Boolean. This option will enable the use of log4j2 xml configuration files.
 # This will override <tt>logging_configuration</tt> to use <tt>log4j2.xml</tt>.
+# This uses RFC5424 formated syslog messages if syslog enabled. Additional info
+# can be parsed out in rsyslog using the mmpstrucdata module.
+# http://www.rsyslog.com/doc/master/configuration/modules/mmpstrucdata.html
 # Defaults to <tt>false</tt>.
 #
 # [*logging_configuration*]
@@ -179,6 +187,7 @@ class repose::filter::container (
   $deployment_directory_auto_clean   = true,
   $jmx_reset_time                    = undef,
   $log_access_facility               = $repose::params::log_access_facility,
+  $log_access_app_name               = $repose::params::log_access_app_name,
   $log_access_local                  = $repose::params::log_access_local,
   $log_access_local_name             = $repose::params::log_access_local_name,
   $log_access_syslog                 = $repose::params::log_access_syslog,

--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -268,7 +268,7 @@ class repose::filter::container (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
   }
 
   file { $logging_configuration_file:

--- a/manifests/filter/content_normalization.pp
+++ b/manifests/filter/content_normalization.pp
@@ -1,6 +1,9 @@
 # == Resource: repose::filter::content_normalization
 #
 # This is a resource for generating content-normalization configuration files
+# DEPRECATED: This has been removed from repose 7+, use URI normalization and
+# header normalization filters instead.
+# See: https://repose.atlassian.net/wiki/display/REPOSE/Upgrade+Repose
 #
 # === Parameters
 #
@@ -66,6 +69,8 @@ define repose::filter::content_normalization (
   $header_filters        = undef,
   $media_types           = undef,
 ) {
+
+  warning("${name} - content normalization filter is incompatibile with repose 7+")
 
 ### Validate parameters
 

--- a/manifests/filter/content_normalization.pp
+++ b/manifests/filter/content_normalization.pp
@@ -99,7 +99,7 @@ define repose::filter::content_normalization (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/dist_datastore.pp
+++ b/manifests/filter/dist_datastore.pp
@@ -90,7 +90,7 @@ define repose::filter::dist_datastore (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/header_normalization.pp
+++ b/manifests/filter/header_normalization.pp
@@ -90,7 +90,7 @@ define repose::filter::header_normalization (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/header_normalization.pp
+++ b/manifests/filter/header_normalization.pp
@@ -33,12 +33,8 @@
 #            {
 #              'name'   => 'rate-limit-headers',
 #              'headers' => [
-#                {
-#                  'id' => 'X-PP-User',
-#                },
-#                {
-#                  'id' => 'X-PP-Groups',
-#                }
+#                'X-PP-User',
+#                'X-PP-Groups',
 #              ],
 #            }
 #          ],
@@ -46,12 +42,8 @@
 #            {
 #              'name'   => 'creds',
 #              'headers' => [
-#                {
-#                  'id' => 'X-Auth-Key',
-#                },
-#                {
-#                  'id' => 'X-Auth-User',
-#                }
+#                'X-Auth-Key',
+#                'X-Auth-User',
 #              ],
 #            }
 #          ],

--- a/manifests/filter/header_normalization.pp
+++ b/manifests/filter/header_normalization.pp
@@ -1,0 +1,105 @@
+# == Resource: repose::filter::header_normalization
+#
+# This is a resource for generating header normalization configuration files
+# NOTE: The uri-normalization and header-translation filters replace the
+# content-normalization filter in repose 7+
+#
+# === Parameters
+#
+# [*ensure*]
+# Bool. Ensure config file present/absent
+# Defaults to <tt>present</tt>
+#
+# [*filename*]
+# String. Config filename
+# Defaults to <tt>header-translaction.cfg.xml</tt>
+#
+# [*header_filters*]
+# List containing targets, blacklist/whitelists and headers
+# Defaults to <tt>undef</tt>
+#
+# === Links
+#
+# * https://repose.atlassian.net/wiki/display/REPOSE/Header+Translation+filter
+#
+# === Examples
+#
+# repose::filter::uri_normalization {
+#   'default':
+#     header_filters => [
+#       {
+#          'http-methods' => 'GET',
+#          'blacklists'   => [
+#            {
+#              'name'   => 'rate-limit-headers',
+#              'headers' => [
+#                {
+#                  'id' => 'X-PP-User',
+#                },
+#                {
+#                  'id' => 'X-PP-Groups',
+#                }
+#              ],
+#            }
+#          ],
+#          'whitelists'   => [
+#            {
+#              'name'   => 'creds',
+#              'headers' => [
+#                {
+#                  'id' => 'X-Auth-Key',
+#                },
+#                {
+#                  'id' => 'X-Auth-User',
+#                }
+#              ],
+#            }
+#          ],
+#       },
+#     ],
+# }
+#
+# === Authors
+#
+# * Alex Schultz <mailto:alex.schultz@rackspace.com>
+# * Greg Swift <mailto:greg.swift@rackspace.com>
+# * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
+#
+define repose::filter::header_normalization (
+  $ensure         = present,
+  $filename       = 'header-normalization.cfg.xml',
+  $header_filters = undef,
+) {
+
+### Validate parameters
+
+## ensure
+  if ! ($ensure in [ present, absent ]) {
+    fail("\"${ensure}\" is not a valid ensure parameter value")
+  } else {
+    $file_ensure = $ensure ? {
+      present => file,
+      absent  => absent,
+    }
+  }
+  if $::debug {
+    debug("\$ensure = '${ensure}'")
+  }
+
+  if $ensure == present {
+    $content_template = template("${module_name}/header-normalization.cfg.xml.erb")
+  } else {
+    $content_template = undef
+  }
+## Manage actions
+
+  file { "${repose::params::configdir}/${filename}":
+    ensure  => $file_ensure,
+    owner   => $repose::params::owner,
+    group   => $repose::params::group,
+    mode    => $repose::params::mode,
+    require => Package['repose-filters'],
+    content => $content_template
+  }
+
+}

--- a/manifests/filter/header_translation.pp
+++ b/manifests/filter/header_translation.pp
@@ -68,7 +68,7 @@ define repose::filter::header_translation (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/http_connection_pool.pp
+++ b/manifests/filter/http_connection_pool.pp
@@ -188,7 +188,7 @@ class repose::filter::http_connection_pool (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/http_logging.pp
+++ b/manifests/filter/http_logging.pp
@@ -92,7 +92,7 @@ define repose::filter::http_logging (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/ip_identity.pp
+++ b/manifests/filter/ip_identity.pp
@@ -80,7 +80,7 @@ define repose::filter::ip_identity (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/metrics.pp
+++ b/manifests/filter/metrics.pp
@@ -101,7 +101,7 @@ define repose::filter::metrics (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 }

--- a/manifests/filter/rackspace_identity_basic_auth.pp
+++ b/manifests/filter/rackspace_identity_basic_auth.pp
@@ -75,7 +75,7 @@ define repose::filter::rackspace_identity_basic_auth (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/rate_limiting.pp
+++ b/manifests/filter/rate_limiting.pp
@@ -128,7 +128,7 @@ define repose::filter::rate_limiting (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/response_messaging.pp
+++ b/manifests/filter/response_messaging.pp
@@ -86,7 +86,7 @@ define repose::filter::response_messaging (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/slf4j_http_logging.pp
+++ b/manifests/filter/slf4j_http_logging.pp
@@ -83,7 +83,7 @@ define repose::filter::slf4j_http_logging (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -162,7 +162,7 @@ define repose::filter::system_model (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => template('repose/system-model.cfg.xml.erb')
   }
 

--- a/manifests/filter/translation.pp
+++ b/manifests/filter/translation.pp
@@ -77,7 +77,7 @@ define repose::filter::translation (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/uri_normalization.pp
+++ b/manifests/filter/uri_normalization.pp
@@ -102,7 +102,7 @@ define repose::filter::uri_normalization (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/filter/uri_normalization.pp
+++ b/manifests/filter/uri_normalization.pp
@@ -1,0 +1,109 @@
+# == Resource: repose::filter::uri_normalization
+#
+# This is a resource for generating uri normalization configuration files
+# NOTE: The uri-normalization and header-translation filters replace the
+# content-normalization filter in repose 7+
+#
+# === Parameters
+#
+# [*ensure*]
+# Bool. Ensure config file present/absent
+# Defaults to <tt>present</tt>
+#
+# [*filename*]
+# String. Config filename
+# Defaults to <tt>header-translaction.cfg.xml</tt>
+#
+# [*uri_filters*]
+# Array of hashes containing array of hashes of targets, whitelists and
+# parameters.  See documentation and example for hash structure.
+# Defaults to <tt>undef</tt>
+#
+# [*media_types*]
+# List of media_types, each containing name, variant-extension, preferred
+# Defaults to <tt>undef</tt>
+#
+# === Links
+#
+# * https://repose.atlassian.net/wiki/display/REPOSE/URI+Normalization+filter
+#
+# === Examples
+#
+# repose::filter::uri_normalization {
+#   'default':
+#     uri_filters => [
+#       {
+#          'uri-regex'    => '',
+#          'http-methods' => 'GET',
+#          'alphabetize'  => 'false',
+#          'whitelists'   => [
+#            {
+#              'id'         => 'something',
+#              'parameters' => [
+#                {
+#                  'name'           => 'test',
+#                  'multiplicity'   => '0',
+#                  'case-sensitive' => 'false',
+#                }
+#              ],
+#            }
+#          ],
+#       }
+#     ],
+#     media_types => [
+#       {
+#         'name'              => 'application/xml',
+#         'variant-extension' => 'xml'
+#       },
+#       {
+#         'name'              => 'application/json',
+#         'variant-extension' => 'json'
+#       },
+#     ]
+# }
+#
+# === Authors
+#
+# * Alex Schultz <mailto:alex.schultz@rackspace.com>
+# * Greg Swift <mailto:greg.swift@rackspace.com>
+# * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
+#
+define repose::filter::uri_normalization (
+  $ensure      = present,
+  $filename    = 'uri-normalization.cfg.xml',
+  $uri_filters = undef,
+  $media_types = undef,
+) {
+
+### Validate parameters
+
+## ensure
+  if ! ($ensure in [ present, absent ]) {
+    fail("\"${ensure}\" is not a valid ensure parameter value")
+  } else {
+    $file_ensure = $ensure ? {
+      present => file,
+      absent  => absent,
+    }
+  }
+  if $::debug {
+    debug("\$ensure = '${ensure}'")
+  }
+
+  if $ensure == present {
+    $content_template = template("${module_name}/uri-normalization.cfg.xml.erb")
+  } else {
+    $content_template = undef
+  }
+## Manage actions
+
+  file { "${repose::params::configdir}/${filename}":
+    ensure  => $file_ensure,
+    owner   => $repose::params::owner,
+    group   => $repose::params::group,
+    mode    => $repose::params::mode,
+    require => Package['repose-filters'],
+    content => $content_template
+  }
+
+}

--- a/manifests/filter/versioning.pp
+++ b/manifests/filter/versioning.pp
@@ -92,7 +92,7 @@ define repose::filter::versioning (
     owner   => $repose::params::owner,
     group   => $repose::params::group,
     mode    => $repose::params::mode,
-    require => Package['repose-filters'],
+    require => Class['::repose::package'],
     content => $content_template
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,14 @@
 # to not break existing users.
 # TODO: Determine a time to default to false. Then when to drop support.
 #
+# [*cfg_new_namespace*]
+# Boolean. Repose 7 introducted new namespaces for the configuration files.
+# This flag is used to indicate the use of the new docs.openrepose.org
+# namespace instead of the docs.rackspacecloud.com namespace. The old namespace
+# url should work but there have been some issues. If running repose >= 7,
+# set this to true.
+# TODO: Determine a time to default to false. Then when to drop support.
+#
 # === Examples
 #
 # * Installation:
@@ -64,11 +72,12 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose (
-  $ensure           = $repose::params::ensure,
-  $enable           = $repose::params::enable,
-  $container        = $repose::params::container,
-  $autoupgrade      = $repose::params::autoupgrade,
-  $rh_old_packages  = $repose::params::rh_old_packages,
+  $ensure            = $repose::params::ensure,
+  $enable            = $repose::params::enable,
+  $container         = $repose::params::container,
+  $autoupgrade       = $repose::params::autoupgrade,
+  $rh_old_packages   = $repose::params::rh_old_packages,
+  $cfg_new_namespace = $repose::params::cfg_new_namespace,
 ) inherits repose::params {
 
 ### Validate parameters
@@ -121,6 +130,12 @@ class repose (
     debug("\$container = '${container}'")
   }
 
+## figure out cfg namespace host
+  if $cfg_new_namespace {
+    $cfg_namespace_host = 'docs.openrepose.org'
+  } else {
+    $cfg_namespace_host = 'docs.rackspacecloud.com'
+  }
 
 ### Manage actions
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,10 +141,10 @@ class repose (
 
 ## package(s)
   class { 'repose::package':
-    ensure           => $ensure,
-    autoupgrade      => $autoupgrade,
-    container        => $container,
-    rh_old_packages  => $rh_old_packages,
+    ensure          => $ensure,
+    autoupgrade     => $autoupgrade,
+    container       => $container,
+    rh_old_packages => $rh_old_packages,
   }
 
 ## service
@@ -160,7 +160,7 @@ class repose (
     mode    => $repose::params::dirmode,
     owner   => $repose::params::owner,
     group   => $repose::params::group,
-    require => Package[$repose::package::packages],
+    require => Package[$repose::package::container_package],
   }
 
   file { $repose::params::configdir:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -179,4 +179,7 @@ class repose::params {
 
 ## default access logging to syslog
   $log_access_syslog = true
+
+## use new namespace urls in configuration files
+  $cfg_new_namespace = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,6 +171,9 @@ class repose::params {
 ## default http access log syslog facility
   $log_access_facility = 'local1'
 
+## default http access log syslog app name
+  $log_access_app_name = ''
+
 ## default access logging locally
   $log_access_local = true
 

--- a/manifests/tomcat7.pp
+++ b/manifests/tomcat7.pp
@@ -46,6 +46,13 @@
 # to not break existing users.
 # TODO: Determine a time to default to false. Then when to drop support.
 #
+# [*cfg_new_namespace*]
+# Boolean. Repose 7 introducted new namespaces for the configuration files.
+# This flag is used to indicate the use of the new docs.openrepose.org
+# namespace instead of the docs.rackspacecloud.com namespace. The old namespace
+# url should work but there have been some issues. If running repose >= 7,
+# set this to true.
+# TODO: Determine a time to default to false. Then when to drop support.
 #
 # === Examples
 #
@@ -64,18 +71,20 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose::tomcat7 (
-  $ensure           = $repose::params::ensure,
-  $enable           = $repose::params::enable,
-  $autoupgrade      = $repose::params::autoupgrade,
-  $rh_old_packages  = $repose::params::rh_old_packages,
+  $ensure            = $repose::params::ensure,
+  $enable            = $repose::params::enable,
+  $autoupgrade       = $repose::params::autoupgrade,
+  $rh_old_packages   = $repose::params::rh_old_packages,
+  $cfg_new_namespace = $repose::params::cfg_new_namespace,
 ) inherits repose::params {
 
   class { 'repose':
-    ensure          => $ensure,
-    enable          => $enable,
-    autoupgrade     => $autoupgrade,
-    rh_old_packages => $rh_old_packages,
-    container       => 'tomcat7',
+    ensure            => $ensure,
+    enable            => $enable,
+    autoupgrade       => $autoupgrade,
+    rh_old_packages   => $rh_old_packages,
+    cfg_new_namespace => $repose::params::cfg_new_namespace,
+    container         => 'tomcat7',
   }
 
 }

--- a/manifests/valve.pp
+++ b/manifests/valve.pp
@@ -69,14 +69,20 @@
 #
 # [*daemonize_opts*]
 # String. The daemonize options to be passed into daemonize.
+# DEPRECATED. This does nothing for repose 7+. This is replaced by a different
+# variable in the sysconfig file but we are not supporting overwriting it.
+# at this time.
 # Defaults to <tt>-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME</tt>
 #
 # [*run_opts*]
-# String. The options sent to the run command
+# String. The options sent to the run command.
+# DEPRECATED. This does nothing for repose 7+. This is replaced by a different
+# variable in the sysconfig file but we are not supporting overwriting it.
 # Defaults to <tt>-p $RUN_PORT -c $CONFIG_DIRECTORY</tt>
 #
 # [*java_options*]
 # String. Additional java options to pass to java_opts
+# NOTE: this also sets JAVA_OPTS for repose 7+
 # Defaults to <tt>undef</tt>
 #
 # [*saxon_home*]
@@ -168,6 +174,7 @@ class repose::valve (
     "set daemonize_opts '\"${daemonize_opts}\"'",
     "set run_opts '\"${run_opts}\"'",
     "set java_opts '\"\${java_opts} ${java_options}\"'",
+    "set JAVA_OPTS '\"\${JAVA_OPTS} ${java_options}\"'",
   ]
 
   # if saxon_home provided for saxon license

--- a/manifests/valve.pp
+++ b/manifests/valve.pp
@@ -90,6 +90,13 @@
 # to not break existing users.
 # TODO: Determine a time to default to false. Then when to drop support.
 #
+# [*cfg_new_namespace*]
+# Boolean. Repose 7 introducted new namespaces for the configuration files.
+# This flag is used to indicate the use of the new docs.openrepose.org
+# namespace instead of the docs.rackspacecloud.com namespace. The old namespace
+# url should work but there have been some issues. If running repose >= 7,
+# set this to true.
+# TODO: Determine a time to default to false. Then when to drop support.
 #
 # === Examples
 #
@@ -109,28 +116,30 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose::valve (
-  $ensure          = $repose::params::ensure,
-  $enable          = $repose::params::enable,
-  $autoupgrade     = $repose::params::autoupgrade,
-  $run_port        = $repose::params::run_port,
-  $daemon_home     = $repose::params::daemon_home,
-  $log_path        = $repose::params::logdir,
-  $pid_file        = $repose::params::pid_file,
-  $user            = $repose::params::user,
-  $daemonize       = $repose::params::daemonize,
-  $daemonize_opts  = $repose::params::daemonize_opts,
-  $run_opts        = $repose::params::run_opts,
-  $java_options    = undef,
-  $saxon_home      = undef,
-  $rh_old_packages = $repose::params::rh_old_packages,
+  $ensure            = $repose::params::ensure,
+  $enable            = $repose::params::enable,
+  $autoupgrade       = $repose::params::autoupgrade,
+  $run_port          = $repose::params::run_port,
+  $daemon_home       = $repose::params::daemon_home,
+  $log_path          = $repose::params::logdir,
+  $pid_file          = $repose::params::pid_file,
+  $user              = $repose::params::user,
+  $daemonize         = $repose::params::daemonize,
+  $daemonize_opts    = $repose::params::daemonize_opts,
+  $run_opts          = $repose::params::run_opts,
+  $java_options      = undef,
+  $saxon_home        = undef,
+  $rh_old_packages   = $repose::params::rh_old_packages,
+  $cfg_new_namespace = $repose::params::cfg_new_namespace,
 ) inherits repose::params {
 
   class { 'repose':
-    ensure          => $ensure,
-    enable          => $enable,
-    autoupgrade     => $autoupgrade,
-    rh_old_packages => $rh_old_packages,
-    container       => 'valve',
+    ensure            => $ensure,
+    enable            => $enable,
+    autoupgrade       => $autoupgrade,
+    rh_old_packages   => $rh_old_packages,
+    cfg_new_namespace => $cfg_new_namespace,
+    container         => 'valve',
   }
 
   file { '/etc/sysconfig/repose':

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.3.6
+Version:   1.4.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Fri Mar 20 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.4.0-1
+- Repose 7 configuration support
 * Tue Jan 20 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.3.6-1
 - Adding configuration for travis-ci
 * Mon Jan 05 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.3.5-1

--- a/spec/classes/filter/container_spec.rb
+++ b/spec/classes/filter/container_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe 'repose::filter::container' do
+
   context 'on RedHat' do
     let :facts do
     {
@@ -353,6 +354,34 @@ describe 'repose::filter::container' do
 
         should contain_file('/etc/repose/container.cfg.xml').
           with_content(/logging-configuration href="file:\/\/\/etc\/repose\/log4j2.xml"/)
+      }
+    end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:params) { {
+        :app_name => 'app'
+      } }
+      it {
+        should contain_file('/etc/repose/container.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:params) { {
+        :app_name => 'app'
+      } }
+      it {
+        should contain_file('/etc/repose/container.cfg.xml').
+          with_content(/docs.openrepose.org/)
       }
     end
 

--- a/spec/classes/filter/http_connection_pool_spec.rb
+++ b/spec/classes/filter/http_connection_pool_spec.rb
@@ -86,5 +86,28 @@ describe 'repose::filter::http_connection_pool', :type => :class do
         )
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      it {
+        should contain_file('/etc/repose/http-connection-pool.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      it {
+        should contain_file('/etc/repose/http-connection-pool.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/classes/valve_spec.rb
+++ b/spec/classes/valve_spec.rb
@@ -31,7 +31,8 @@ describe 'repose::valve' do
           "set daemonize '/usr/sbin/daemonize'",
           "set daemonize_opts '\"-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME\"'",
           "set run_opts '\"-p $RUN_PORT -c $CONFIG_DIRECTORY\"'",
-          "set java_opts '\"${java_opts} \"'"
+          "set java_opts '\"${java_opts} \"'",
+          "set JAVA_OPTS '\"${JAVA_OPTS} \"'"
           ],
           "rm SAXON_HOME"
         ])

--- a/spec/classes/valve_spec.rb
+++ b/spec/classes/valve_spec.rb
@@ -68,5 +68,19 @@ describe 'repose::valve' do
       }
     end
 
+    context 'with new namespaces' do
+      let(:params) { { :cfg_new_namespace => 'true' } }
+      it {
+        should contain_class('repose').with(
+          'ensure'            => 'present',
+          'enable'            => 'true',
+          'autoupgrade'       => 'false',
+          'rh_old_packages'   => 'true',
+          'cfg_new_namespace' => 'true',
+          'container'         => 'valve'
+        )
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/api_validator_spec.rb
+++ b/spec/defines/filter/api_validator_spec.rb
@@ -77,5 +77,50 @@ describe 'repose::filter::api_validator', :type => :define do
           with_content(/mask-rax-roles-403="true"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :validators => [ {
+          'role'                         => 'app',
+          'default'                      => true,
+          'wadl'                         => 'usage-schema/app.wadl',
+          'check_well_formed'            => true
+        }, ]
+      } }
+
+      it {
+        should contain_file('/etc/repose/validator.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :validators => [ {
+          'role'                         => 'app',
+          'default'                      => true,
+          'wadl'                         => 'usage-schema/app.wadl',
+          'check_well_formed'            => true
+        }, ]
+      } }
+
+      it {
+        should contain_file('/etc/repose/validator.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -203,7 +203,7 @@ describe 'repose::filter::client_auth_n', :type => :define do
           with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
           with_content(/client-mapping id-regex=\"testing\"/).
           without_content(/delegable=/).
-          with_content(/delegating=\"true\"/).
+          with_content(/delegating quality=\"0\.5\"/).
           with_content(/tenanted=\"false\"/).
           with_content(/group-cache-timeout=\"60000\"/).
           without_content(/connectionPoolId/).

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -211,5 +211,49 @@ describe 'repose::filter::client_auth_n', :type => :define do
       }
     end
 
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'client-auth-n.cfg.xml',
+        :auth       => {
+          'user' => 'username',
+          'pass' => 'password',
+          'uri'  => 'http://uri'
+        },
+        :client_maps => [ 'testing', ],
+      } }
+      it {
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'client-auth-n.cfg.xml',
+        :auth       => {
+          'user' => 'username',
+          'pass' => 'password',
+          'uri'  => 'http://uri'
+        },
+        :client_maps => [ 'testing', ],
+      } }
+      it {
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -52,6 +52,7 @@ describe 'repose::filter::client_auth_n', :type => :define do
           with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
           with_content(/client-mapping id-regex=\"testing\"/).
           with_content(/delegable=\"false\"/).
+          without_content(/delegating/).
           with_content(/tenanted=\"false\"/).
           with_content(/group-cache-timeout=\"60000\"/).
           without_content(/connectionPoolId/).
@@ -176,6 +177,37 @@ describe 'repose::filter::client_auth_n', :type => :define do
         should contain_file('/etc/repose/client-auth-n.cfg.xml').
                    with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
                    with_content(/send-all-tenant-ids=\"true\"/)
+      }
+    end
+
+    context 'providing delegating for repose 7+' do
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'client-auth-n.cfg.xml',
+        :auth       => {
+          'user' => 'username',
+          'pass' => 'password',
+          'uri'  => 'http://uri'
+        },
+        :client_maps => [ 'testing', ],
+        :delegating  => 'true'
+      } }
+      it {
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').with(
+          :ensure => 'file',
+          :owner => 'repose',
+          :group => 'repose'
+        )
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').
+          with_content(/identity-service username=\"username\" password=\"password\" uri=\"http:\/\/uri\"/).
+          with_content(/client-mapping id-regex=\"testing\"/).
+          without_content(/delegable=/).
+          with_content(/delegating=\"true\"/).
+          with_content(/tenanted=\"false\"/).
+          with_content(/group-cache-timeout=\"60000\"/).
+          without_content(/connectionPoolId/).
+          without_content(/token-cache-timeout/)
       }
     end
 

--- a/spec/defines/filter/compression_spec.rb
+++ b/spec/defines/filter/compression_spec.rb
@@ -30,5 +30,29 @@ describe 'repose::filter::compression', :type => :define do
       }
     end
 
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/compression.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/compression.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/content_normalization_spec.rb
+++ b/spec/defines/filter/content_normalization_spec.rb
@@ -55,5 +55,30 @@ describe 'repose::filter::content_normalization', :type => :define do
           with_content(/<\/media-types>/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/content-normalization.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/content-normalization.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/dist_datastore_spec.rb
+++ b/spec/defines/filter/dist_datastore_spec.rb
@@ -46,5 +46,39 @@ describe 'repose::filter::dist_datastore', :type => :define do
           with_content(/<allow host=\"test\.example\.com\" \/>/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'dist-datastore.cfg.xml',
+        :nodes      => [ 'test.example.com', ]
+      } }
+      it {
+        should contain_file('/etc/repose/dist-datastore.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'dist-datastore.cfg.xml',
+        :nodes      => [ 'test.example.com', ]
+      } }
+      it {
+        should contain_file('/etc/repose/dist-datastore.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/header_normalization_spec.rb
+++ b/spec/defines/filter/header_normalization_spec.rb
@@ -69,5 +69,29 @@ describe 'repose::filter::header_normalization', :type => :define do
           with_content(/header id="X-Auth-User"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/header-normalization.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/header-normalization.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/header_normalization_spec.rb
+++ b/spec/defines/filter/header_normalization_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+describe 'repose::filter::header_normalization', :type => :define do
+  let :pre_condition do
+    'include repose'
+  end
+  context 'on RedHat' do
+    let :facts do
+    {
+      :osfamily               => 'RedHat',
+      :operationsystemrelease => '6',
+    }
+    end
+
+    context 'default parameters' do
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/header-normalization.cfg.xml')
+      }
+    end
+
+    context 'with ensure absent' do
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure => 'absent'
+      } }
+      it {
+        should contain_file('/etc/repose/header-normalization.cfg.xml').with_ensure(
+          'absent')
+      }
+    end
+
+    context 'with header_filters' do
+      let(:title) { 'headers' }
+      let(:params) { {
+        :header_filters => [
+         {
+            'uri-regex'    => '/.*test',
+            'http-methods' => 'GET',
+            'blacklists'   => [
+              {
+                'id'    => 'rate-limit-headers',
+                'headers' => [
+                  'X-PP-User',
+                  'X-PP-Groups'
+                ]
+              }
+            ],
+            'whitelists'   => [
+              {
+                'id'    => 'creds',
+                'headers' => [
+                  'X-Auth-Key',
+                  'X-Auth-User'
+                ]
+              }
+            ],
+         }
+       ]
+      } }
+      it {
+        should contain_file('/etc/repose/header-normalization.cfg.xml').
+          with_content(/uri-regex="\/\.\*test"/).
+          with_content(/http-methods="GET"/).
+          with_content(/blacklist id="rate-limit-headers"/).
+          with_content(/header id="X-PP-User"/).
+          with_content(/header id="X-PP-Groups"/).
+          with_content(/whitelist id="creds"/).
+          with_content(/header id="X-Auth-Key"/).
+          with_content(/header id="X-Auth-User"/)
+      }
+    end
+  end
+end

--- a/spec/defines/filter/header_translation_spec.rb
+++ b/spec/defines/filter/header_translation_spec.rb
@@ -52,5 +52,29 @@ describe 'repose::filter::header_translation', :type => :define do
         )
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/header-translation.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/header-translation.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/http_logging_spec.rb
+++ b/spec/defines/filter/http_logging_spec.rb
@@ -51,5 +51,47 @@ describe 'repose::filter::http_logging', :type => :define do
           with_content(/<file location=\"\/var\/log\/repose\/http.log\"\/>/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'http-logging.cfg.xml',
+        :log_files  => [ {
+          'id'       => 'my-log',
+          'format'   => 'my format',
+          'location' => '/var/log/repose/http.log'
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/http-logging.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'http-logging.cfg.xml',
+        :log_files  => [ {
+          'id'       => 'my-log',
+          'format'   => 'my format',
+          'location' => '/var/log/repose/http.log'
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/http-logging.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/ip_identity_spec.rb
+++ b/spec/defines/filter/ip_identity_spec.rb
@@ -52,5 +52,47 @@ describe 'repose::filter::ip_identity', :type => :define do
           with_content(/<ip-address>9\.9\.9\.9<\/ip-address>/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure    => 'present',
+        :filename  => 'ip-identity.cfg.xml',
+        :quality   => '0.25',
+        :whitelist => {
+          'quality'   => '0.3',
+          'addresses' => [ '9.9.9.9', ],
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/ip-identity.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure    => 'present',
+        :filename  => 'ip-identity.cfg.xml',
+        :quality   => '0.25',
+        :whitelist => {
+          'quality'   => '0.3',
+          'addresses' => [ '9.9.9.9', ],
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/ip-identity.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/metrics_spec.rb
+++ b/spec/defines/filter/metrics_spec.rb
@@ -55,5 +55,51 @@ describe 'repose::filter::metrics', :type => :define do
           with_content(/prefix=\"my\/prefix\"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'metrics.cfg.xml',
+        :graphite_servers => [ {
+          'host'    => 'graphite.server',
+          'port'    => '2013',
+          'period'  => 10,
+          'prefix'  => 'my/prefix',
+          'enabled' => 'true'
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/metrics.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'metrics.cfg.xml',
+        :graphite_servers => [ {
+          'host'    => 'graphite.server',
+          'port'    => '2013',
+          'period'  => 10,
+          'prefix'  => 'my/prefix',
+          'enabled' => 'true'
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/metrics.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/rackspace_identity_basic_auth_spec.rb
+++ b/spec/defines/filter/rackspace_identity_basic_auth_spec.rb
@@ -53,5 +53,29 @@ describe 'repose::filter::rackspace_identity_basic_auth', :type => :define do
         should contain_file('/etc/repose/rackspace-identity-basic-auth.cfg.xml').with_content(/token-cache-timeout-millis="1000"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/rackspace-identity-basic-auth.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/rackspace-identity-basic-auth.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/rate_limiting_spec.rb
+++ b/spec/defines/filter/rate_limiting_spec.rb
@@ -180,5 +180,74 @@ describe 'repose::filter::rate_limiting', :type => :define do
       }
     end
 
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'rate-limiting.cfg.xml',
+        :request_endpoint => {
+          'uri-regex'              => '/limits/stuff/?',
+          'include_absolut_limits' => false
+        },
+        :limit_groups => [ {
+          'id'        => 'Some_Group',
+          'groups'    => 'Some_Group',
+          'default'   => true,
+          'limits'    => [
+          {
+            'id'           => 'some_limit_id',
+            'uri'          => '/.*',
+            'uri_regex'    => '/.*',
+            'http_methods' => 'GET',
+            'unit'         => 'SECOND',
+            'value'        => '200'
+          },
+          ]
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/rate-limiting.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'rate-limiting.cfg.xml',
+        :request_endpoint => {
+          'uri-regex'              => '/limits/stuff/?',
+          'include_absolut_limits' => false
+        },
+        :limit_groups => [ {
+          'id'        => 'Some_Group',
+          'groups'    => 'Some_Group',
+          'default'   => true,
+          'limits'    => [
+          {
+            'id'           => 'some_limit_id',
+            'uri'          => '/.*',
+            'uri_regex'    => '/.*',
+            'http_methods' => 'GET',
+            'unit'         => 'SECOND',
+            'value'        => '200'
+          },
+          ]
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/rate-limiting.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/response_messaging_spec.rb
+++ b/spec/defines/filter/response_messaging_spec.rb
@@ -58,5 +58,59 @@ describe 'repose::filter::response_messaging', :type => :define do
           with_content(/\{ \"overLimit\" : \{ \"code\" : 413, \"message\" : \"OverLimit Retry\.\.\.\", \"details\" : \"whatever\": \} \}/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'response-messaging.cfg.xml',
+        :status_codes  => [
+        {
+          'id'         => '413',
+          'code-regex' => '413',
+          'messages'   => [
+            {
+              'media-type' => '*/*',
+              'body' => '{ "overLimit" : { "code" : 413, "message" : "OverLimit Retry...", "details" : "whatever": } }',
+            }
+          ]
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/response-messaging.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'response-messaging.cfg.xml',
+        :status_codes  => [
+        {
+          'id'         => '413',
+          'code-regex' => '413',
+          'messages'   => [
+            {
+              'media-type' => '*/*',
+              'body' => '{ "overLimit" : { "code" : 413, "message" : "OverLimit Retry...", "details" : "whatever": } }',
+            }
+          ]
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/response-messaging.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/slf4j_http_logging_spec.rb
+++ b/spec/defines/filter/slf4j_http_logging_spec.rb
@@ -50,5 +50,45 @@ describe 'repose::filter::slf4j_http_logging', :type => :define do
           with_content(/format=\"my format\"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'slf4j-http-logging.cfg.xml',
+        :log_files  => [ {
+          'id'       => 'my-log',
+          'format'   => 'my format',
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/slf4j-http-logging.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'slf4j-http-logging.cfg.xml',
+        :log_files  => [ {
+          'id'       => 'my-log',
+          'format'   => 'my format',
+        } ]
+      } }
+      it {
+        should contain_file('/etc/repose/slf4j-http-logging.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -224,5 +224,67 @@ describe 'repose::filter::system_model', :type => :define do
           with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'system-model.cfg.xml',
+        :app_name   => 'repose',
+        :nodes      => ['app1', 'app2' ],
+        :filters    => {
+          90 => { 'name' => 'api-validator' },
+        },
+        :endpoints  => [
+          {
+            'id'        => 'localhost',
+            'protocol'  => 'http',
+            'hostname'  => 'localhost',
+            'root-path' => '',
+            'port'      => '80',
+            'default'   => 'true'
+          },
+        ]
+      } }
+      it {
+        should contain_file('/etc/repose/system-model.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'system-model.cfg.xml',
+        :app_name   => 'repose',
+        :nodes      => ['app1', 'app2' ],
+        :filters    => {
+          90 => { 'name' => 'api-validator' },
+        },
+        :endpoints  => [
+          {
+            'id'        => 'localhost',
+            'protocol'  => 'http',
+            'hostname'  => 'localhost',
+            'root-path' => '',
+            'port'      => '80',
+            'default'   => 'true'
+          },
+        ]
+      } }
+      it {
+        should contain_file('/etc/repose/system-model.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/template.rb
+++ b/spec/defines/filter/template.rb
@@ -39,5 +39,29 @@ describe 'repose::filter::CHANGEME', :type => :define do
         should contain_file('/etc/repose/CHANGEME.cfg.xml')
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/CHANGEME.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/CHANGEME.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/translation_spec.rb
+++ b/spec/defines/filter/translation_spec.rb
@@ -72,5 +72,30 @@ describe 'repose::filter::translation', :type => :define do
           with_content(/id=\"wadly\" href=\"schema\/wadl\/mywadl\.xsl\"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/translation.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/translation.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/uri_normalization_spec.rb
+++ b/spec/defines/filter/uri_normalization_spec.rb
@@ -80,5 +80,29 @@ describe 'repose::filter::uri_normalization', :type => :define do
           with_content(/name="test"/)
       }
     end
+
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
   end
 end

--- a/spec/defines/filter/uri_normalization_spec.rb
+++ b/spec/defines/filter/uri_normalization_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+describe 'repose::filter::uri_normalization', :type => :define do
+  let :pre_condition do
+    'include repose'
+  end
+  context 'on RedHat' do
+    let :facts do
+    {
+      :osfamily               => 'RedHat',
+      :operationsystemrelease => '6',
+    }
+    end
+
+    context 'default parameters' do
+      let(:title) { 'default' }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml')
+      }
+    end
+
+    context 'with ensure absent' do
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure => 'absent'
+      } }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml').with_ensure(
+          'absent')
+      }
+    end
+
+    context 'with media_types' do
+      let(:title) { 'headers' }
+      let(:params) { {
+        :media_types => [
+          { 'name' => 'application/xml', 'variant-extension' => 'xml' },
+          { 'name' => 'application/json', 'variant-extension' => 'json' },
+        ]
+      } }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml').
+          with_content(/<media-variants>/).
+          with_content(/<media-type name=\"application\/xml\" variant-extension=\"xml\" \/>/).
+          with_content(/<media-type name=\"application\/json\" variant-extension=\"json\" \/>/).
+          with_content(/<\/media-variants>/)
+      }
+    end
+
+    context 'with uri_filters' do
+      let(:title) { 'headers' }
+      let(:params) { {
+        :uri_filters => [
+         {
+            'uri-regex'    => '/.*test',
+            'http-methods' => 'GET',
+            'alphabetize'  => 'false',
+            'whitelists'   => [
+              {
+                'id'         => 'something',
+                'parameters' => [
+                  {
+                    'name'           => 'test',
+                    'multiplicity'   => '0',
+                    'case-sensitive' => 'false',
+                  }
+                ],
+              }
+            ],
+         }
+       ]
+      } }
+      it {
+        should contain_file('/etc/repose/uri-normalization.cfg.xml').
+          with_content(/uri-regex="\/\.\*test"/).
+          with_content(/http-methods="GET"/).
+          with_content(/alphabetize="false"/).
+          with_content(/whitelist id="something"/).
+          with_content(/case-sensitive="false"/).
+          with_content(/multiplicity="0"/).
+          with_content(/name="test"/)
+      }
+    end
+  end
+end

--- a/spec/defines/filter/versioning_spec.rb
+++ b/spec/defines/filter/versioning_spec.rb
@@ -76,5 +76,39 @@ describe 'repose::filter::versioning', :type => :define do
       }
     end
 
+    context 'with defaults with old namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'versioning.cfg.xml',
+        :target_uri => 'http://localhost/repose',
+      } }
+      it {
+        should contain_file('/etc/repose/versioning.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'versioning.cfg.xml',
+        :target_uri => 'http://localhost/repose',
+      } }
+      it {
+        should contain_file('/etc/repose/versioning.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+
   end
 end

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
+<client-auth xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/client-auth/v1.0">
     <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% else %>delegating="<%= @delegating %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
         <identity-service username="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>" uri="<%= @auth['uri'] -%>" />
 <%- if @client_maps -%>

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/client-auth/v1.0">
-    <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% else %>delegating="<%= @delegating %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+    <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/client-auth/os-ids-auth/v1.0">
+<%- if ! @delegating.nil? -%>
+  <%- if @delegating %>
+        <delegating quality="0.5"/>
+  <%- end -%>
+<%- end -%>
         <identity-service username="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>" uri="<%= @auth['uri'] -%>" />
 <%- if @client_maps -%>
   <% @client_maps.each do |client_map| -%>

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
-    <openstack-auth delegable="<%= @delegable %>" tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+    <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% else %>delegating="<%= @delegating %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
         <identity-service username="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>" uri="<%= @auth['uri'] -%>" />
 <%- if @client_maps -%>
   <% @client_maps.each do |client_map| -%>

--- a/templates/compression.cfg.xml.erb
+++ b/templates/compression.cfg.xml.erb
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<content-compression xmlns="http://docs.api.rackspacecloud.com/repose/content-compression/v1.0">
+<content-compression xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-compression/v1.0">
     <compression compression-threshold="<%= @threshold %>" debug="<%= @debug %>" include-content-types="<%= @include_content_types.join(',') %>"<% if ! @exclude_content_types.nil? %> exclude-content-types="<%= @exclude_content_type.join(',') %>"<% end -%> />
 </content-compression>

--- a/templates/container.cfg.xml.erb
+++ b/templates/container.cfg.xml.erb
@@ -36,7 +36,11 @@
 
         <artifact-directory check-interval="<%= @artifact_directory_check_interval %>"><%= @artifact_directory %></artifact-directory>
 
+<%- if @log_use_log4j2 == true -%>
+        <logging-configuration href="file://<%= @logging_configuration_file %>"/>
+<%- else -%>
         <logging-configuration href="<%= @logging_configuration %>"/>
+<%- end -%>
 
 <%- if @ssl_enabled == true -%>
         <ssl-configuration>

--- a/templates/container.cfg.xml.erb
+++ b/templates/container.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
-<repose-container xmlns='http://docs.rackspacecloud.com/repose/container/v2.0'>
+<repose-container xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/container/v2.0'>
     <deployment-config
 <%- if @http_port -%>
         http-port="<%= @http_port %>"

--- a/templates/container.cfg.xml.erb
+++ b/templates/container.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
-<repose-container xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/container/v2.0'>
+<repose-container xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/container/v2.0">
     <deployment-config
 <%- if @http_port -%>
         http-port="<%= @http_port %>"

--- a/templates/content-normalization.cfg.xml.erb
+++ b/templates/content-normalization.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<content-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-normalization/v1.0'>
+<content-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-normalization/v1.0">
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |filter| -%>

--- a/templates/content-normalization.cfg.xml.erb
+++ b/templates/content-normalization.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <content-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-                       xmlns='http://docs.api.rackspacecloud.com/repose/content-normalization/v1.0'>
+    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-normalization/v1.0'>
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |filter| -%>

--- a/templates/dist-datastore.cfg.xml.erb
+++ b/templates/dist-datastore.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
-<distributed-datastore xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/distributed-datastore/v1.0'>
+<distributed-datastore xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/distributed-datastore/v1.0">
    <allowed-hosts allow-all="<%= allow_all %>">
       <allow host="127.0.0.1" />
 <% nodes.each do |node| -%>

--- a/templates/dist-datastore.cfg.xml.erb
+++ b/templates/dist-datastore.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
-<distributed-datastore xmlns='http://openrepose.org/repose/distributed-datastore/v1.0'>
+<distributed-datastore xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/distributed-datastore/v1.0'>
    <allowed-hosts allow-all="<%= allow_all %>">
       <allow host="127.0.0.1" />
 <% nodes.each do |node| -%>

--- a/templates/header-normalization.cfg.xml.erb
+++ b/templates/header-normalization.cfg.xml.erb
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<header-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                      xmlns='http://docs.openrepose.org/repose/header-normalization/v1.0'
+                      xsi:schemaLocation='http://docs.openrepose.org/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd'>
+<%- if @header_filters -%>
+    <header-filters>
+  <%- @header_filters.each do |target| -%>
+        <target
+    <%- if target.has_key?('uri-regex') -%>
+            uri-regex="<%= target['uri-regex'] %>"
+    <%- end -%>
+    <%- if target.has_key?('http-methods') -%>
+            http-methods="<%= target['http-methods'] %>"
+    <%- end -%>
+            >
+    <%- if target.has_key?('whitelists') -%>
+      <%- target['whitelists'].each do |whitelist| -%>
+            <whitelist id="<%= whitelist['id'] %>">
+        <%- if whitelist.has_key?('headers') -%>
+           <%- whitelist['headers'].each do |header| -%>
+                <header id="<%= header %>"/>
+           <%- end -%>
+        <%- end -%>
+            </whitelist>
+      <%- end -%>
+    <%- end -%>
+    <%- if target.has_key?('blacklists') -%>
+      <%- target['blacklists'].each do |blacklist| -%>
+            <blacklist id="<%= blacklist['id'] %>">
+        <%- if blacklist.has_key?('headers') -%>
+           <%- blacklist['headers'].each do |header| -%>
+                <header id="<%= header %>"/>
+           <%- end -%>
+        <%- end -%>
+            </blacklist>
+      <%- end -%>
+    <%- end -%>
+    </target>
+  <%- end -%>
+    </header-filters>
+<%- end -%>
+</headers-normalization>

--- a/templates/header-normalization.cfg.xml.erb
+++ b/templates/header-normalization.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<header-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0'
-    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd'>
+<header-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0"
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd">
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |target| -%>

--- a/templates/header-normalization.cfg.xml.erb
+++ b/templates/header-normalization.cfg.xml.erb
@@ -39,4 +39,4 @@
   <%- end -%>
     </header-filters>
 <%- end -%>
-</headers-normalization>
+</header-normalization>

--- a/templates/header-normalization.cfg.xml.erb
+++ b/templates/header-normalization.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <header-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-                      xmlns='http://docs.openrepose.org/repose/header-normalization/v1.0'
-                      xsi:schemaLocation='http://docs.openrepose.org/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd'>
+    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0'
+    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd'>
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |target| -%>

--- a/templates/header-translation.cfg.xml.erb
+++ b/templates/header-translation.cfg.xml.erb
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0 ../config/header-translation.xsd"
- xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-translation/v1.0 ../config/header-translation.xsd"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-translation/v1.0">
 <%- if @header_translations -%>
   <%- @header_translations.each do |header_translation| -%>
     <header original-name="<%= header_translation['original_name'] -%>" new-name="<%= header_translation['new_name'] -%>" remove-original="<%= header_translation['remove_original'] -%>" />

--- a/templates/http-connection-pool.cfg.xml.erb
+++ b/templates/http-connection-pool.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<http-connection-pools xmlns="http://docs.rackspacecloud.com/repose/http-connection-pool/v1.0">
+<http-connection-pools xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/http-connection-pool/v1.0">
 
     <!-- Configuration for the default pool.  Any users of the service will by default, retrieve HTTP connections
         using this default pool configuration.

--- a/templates/http-logging.cfg.xml.erb
+++ b/templates/http-logging.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/HTTP+Logging+Filter -->
-<http-logging xmlns="http://docs.rackspacecloud.com/repose/http-logging/v1.0">
+<http-logging xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/http-logging/v1.0">
     <!-- The id attribute is to help the user easily identify the log -->
     <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config
          found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->

--- a/templates/ip-identity.cfg.xml.erb
+++ b/templates/ip-identity.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ip-identity  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-              xmlns='http://docs.api.rackspacecloud.com/repose/ip-identity/v1.0'
-              xsi:schemaLocation='http://docs.api.rackspacecloud.com/repose/ip-identity/v1.0'>
+    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0'
+    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0'>
     <quality><%= @quality %></quality>
     <white-list quality="<%= @whitelist['quality'] %>">
 <% @whitelist['addresses'].each do |address| %>

--- a/templates/ip-identity.cfg.xml.erb
+++ b/templates/ip-identity.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ip-identity  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0'
-    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0'>
+<ip-identity  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0"
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0">
     <quality><%= @quality %></quality>
     <white-list quality="<%= @whitelist['quality'] %>">
 <% @whitelist['addresses'].each do |address| %>

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -38,10 +38,8 @@
                 port="<%= @syslog_port %>"
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_repose_facility %>"
+                mcdId="mcd"
                 >
-            <PatternLayout>
-                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
-            </PatternLayout>
         </Syslog>
 <%- end -%>
 <%- if @log_access_syslog and @syslog_server -%>
@@ -50,10 +48,8 @@
                 port="<%= @syslog_port %>"
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_access_facility %>"
+                mcdId="mcd"
                 >
-            <PatternLayout>
-                <Pattern>%m%n</Pattern>
-            </PatternLayout>
         </Syslog>
 <%- end -%>
 <%- if @log_access_local -%>

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout>
+                <Pattern>%d %-r4 [%t] %-5p %c - %m%n</Pattern>
+            </PatternLayout>
+        </Console>
+<%- if @log_local_policy == 'date' -%>
+        <RollingFile name="defaultFile"
+            filename="<%= @log_dir-%>/<%= @app_name -%>.log"
+            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%d{yyyy-MM-dd}">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+            </Policies>
+        </RollingFile>
+<%- elsif @log_local_policy == 'size' -%>
+        <RollingFile name="defaultFile"
+            filename="<%= @log_dir-%>/<%= @app_name -%>.log"
+            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="<%= @log_local_size %>" />
+            </Policies>
+            <DefaultRolloverStrategy max="<%= @log_local_rotation_count %>"/>
+        </RollingFile>
+<%- else -%>
+        <File name="defaultFile" filename="/dev/null" />
+<%- end -%>
+<%- if @syslog_server -%>
+        <Syslog name="syslog" format="RFC5424"
+                host="<%= @syslog_server %>"
+                port="<%= @syslog_port %>"
+                protocol="<%= @syslog_protocol %>"
+                facility="<%= @log_repose_facility %>"
+                >
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
+            </PatternLayout>
+        </Syslog>
+<%- end -%>
+<%- if @log_access_syslog and @syslog_server -%>
+        <Syslog name="httpSyslog" format="RFC5424"
+                host="<%= @syslog_server %>"
+                port="<%= @syslog_port %>"
+                protocol="<%= @syslog_protocol %>"
+                facility="<%= @log_access_facility %>"
+                >
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+        </Syslog>
+<%- end -%>
+<%- if @log_access_local -%>
+  <%- if @log_local_policy == 'date' -%>
+        <RollingFile name="httpLocal"
+            filename="<%= @log_dir-%>/<%= @log_access_local_name -%>.log"
+            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%d{yyyy-MM-dd}">
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+            </Policies>
+        </RollingFile>
+  <%- elsif @log_local_policy == 'size' -%>
+        <RollingFile name="httpLocal"
+            filename="<%= @log_dir-%>/<%= @log_access_local_name -%>.log"
+            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%i">
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="<%= @log_local_size %>" />
+            </Policies>
+            <DefaultRolloverStrategy max="<%= @log_local_rotation_count %>"/>
+        </RollingFile>
+  <%- else -%>
+        <File name="httpLocal" filename="/dev/null" />
+  <%- end -%>
+<%- end -%>
+    </Appenders>
+    <Loggers>
+<%-
+# if syslog_server is provided, then add it to the root appenders
+if @syslog_server
+  rootAppenders = [ "syslog", "defaultFile" ]
+else
+  rootAppenders = [ "defaultFile" ]
+end
+-%>
+        <Root level="<%= @log_level %>">
+<%-
+  rootAppenders.each do |appender|
+-%>
+            <AppenderRef ref="<%= appender %>"/>
+<%- end -%>
+        </Root>
+        <Logger name="com.sun.jersey" level="off"/>
+        <Logger name="net.sf.ehcache" level="error"/>
+        <Logger name="org.apache.commons.httpclient" level="warn"/>
+        <Logger name="org.eclipse.jetty" level="off"/>
+        <Logger name="org.openrepose" level="info"/>
+        <Logger name="org.rackspace.deproxy" level="info"/>
+        <Logger name="org.springframework" level="warn"/>
+        <Logger name="intrafilter-logging" level="info"/>
+        <Logger name="http" level="info">
+<%-
+# if setup the appropriate access log appenders
+httpAppenders = Array.new()
+if @log_access_syslog and @syslog_server
+  httpAppenders.push("httpSyslog")
+end
+if @log_access_local
+  httpAppenders.push("httpLocal")
+end
+if ! httpAppenders.empty?
+  httpAppenders.each do |appender|
+-%>
+            <AppenderRef ref="<%= appender %>"/>
+  <%- end -%>
+<%- end -%>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -38,8 +38,16 @@
                 port="<%= @syslog_port %>"
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_repose_facility %>"
+                appName="<%= @app_name %>"
                 mcdId="mcd"
                 >
+            <LoggerFields>
+                <KeyValuePair key="thread" value="%t"/>
+                <KeyValuePair key="priority" value="%p"/>
+                <KeyValuePair key="category" value="%c"/>
+                <KeyValuePair key="level" value="%-5p"/>
+                <KeyValuePair key="ndc" value="%x"/>
+            </LoggerFields>
         </Syslog>
 <%- end -%>
 <%- if @log_access_syslog and @syslog_server -%>
@@ -48,6 +56,7 @@
                 port="<%= @syslog_port %>"
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_access_facility %>"
+                appName="<%= @log_access_app_name %>"
                 mcdId="mcd"
                 >
         </Syslog>

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration monitorInterval="30">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout>
@@ -114,7 +114,7 @@ end
         <Logger name="org.rackspace.deproxy" level="info"/>
         <Logger name="org.springframework" level="warn"/>
         <Logger name="intrafilter-logging" level="info"/>
-        <Logger name="http" level="info">
+        <Logger name="http" level="info" additivity="false">
 <%-
 # if setup the appropriate access log appenders
 httpAppenders = Array.new()

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -39,7 +39,7 @@
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_repose_facility %>"
                 appName="<%= @app_name %>"
-                mcdId="mcd"
+                mdcId="mdc"
                 >
             <LoggerFields>
                 <KeyValuePair key="thread" value="%t"/>
@@ -57,7 +57,7 @@
                 protocol="<%= @syslog_protocol %>"
                 facility="<%= @log_access_facility %>"
                 appName="<%= @log_access_app_name %>"
-                mcdId="mcd"
+                mdcId="mdc"
                 >
         </Syslog>
 <%- end -%>

--- a/templates/metrics.cfg.xml.erb
+++ b/templates/metrics.cfg.xml.erb
@@ -1,4 +1,4 @@
-<metrics xmlns="http://docs.rackspacecloud.com/repose/metrics/v1.0" enabled="<%= enabled %>">
+<metrics xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/metrics/v1.0" enabled="<%= enabled %>">
     <graphite>
     <%- graphite_servers.each do | server | -%>
         <server host="<%= server[ 'host' ] %>"

--- a/templates/rackspace-identity-basic-auth.cfg.xml.erb
+++ b/templates/rackspace-identity-basic-auth.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <rackspace-identity-basic-auth
-    xmlns="http://docs.openrepose.org/rackspace-identity-basic-auth/v1.0"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/rackspace-identity-basic-auth/v1.0"
     rackspace-identity-service-uri="<%= @identity_service_url %>"
     token-cache-timeout-millis="<%= @token_cache_timeout %>"/>

--- a/templates/rackspace-identity-basic-auth.cfg.xml.erb
+++ b/templates/rackspace-identity-basic-auth.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <rackspace-identity-basic-auth
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/rackspace-identity-basic-auth/v1.0"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/rackspace-identity-basic-auth/v1.0"
     rackspace-identity-service-uri="<%= @identity_service_url %>"
     token-cache-timeout-millis="<%= @token_cache_timeout %>"/>

--- a/templates/rate-limiting.cfg.xml.erb
+++ b/templates/rate-limiting.cfg.xml.erb
@@ -2,7 +2,7 @@
 <!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
 <rate-limiting <%- if ! @datastore.nil? %>datastore="<%= @datastore %>"<% end %> <%- if ! @overlimit_429.nil? %>overLimit-429-responseCode="<%= @overlimit_429%>"<% end %> 
     use-capture-groups="<%= use_capture_groups %>"
-    xmlns="http://docs.rackspacecloud.com/repose/rate-limiting/v1.0">
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/rate-limiting/v1.0">
     <!--
         Defines an endpoint with a matching regex to bind GET requests for
         returning live rate limiting information.

--- a/templates/response-messaging.cfg.xml.erb
+++ b/templates/response-messaging.cfg.xml.erb
@@ -3,7 +3,7 @@
 <!-- http://wiki.openrepose.org/display/REPOSE/Response+Messaging+Service -->
 <!-- The Response Messaging Service (RMS) allows you to configure the HTTP response returned to the client
      for specific HTTP status codes. -->
-<response-messaging xmlns="http://docs.rackspacecloud.com/repose/response-messaging/v1.0">
+<response-messaging xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/response-messaging/v1.0">
 <% @status_codes.each do |code| -%>
     <status-code id="<%= code['id'] %>" code-regex="<%= code['code-regex'] %>" <% if code.has_key?('overwrite') %>overwrite="<%= code['overwrite'] %>"<% end %>>
   <%- code['messages'].each do |message| -%>

--- a/templates/slf4j-http-logging.cfg.xml.erb
+++ b/templates/slf4j-http-logging.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://repose.atlassian.net/wiki/display/REPOSE/SLF4J+HTTP+Logging+Filter -->
-<slf4j-http-logging xmlns="http://docs.rackspacecloud.com/repose/slf4j-http-logging/v1.0">
+<slf4j-http-logging xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/slf4j-http-logging/v1.0">
     <!-- The id attribute is to help the user easily identify the log 
          it can then be used in log4j backend to determin which appender to go to -->
     <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
-<system-model xmlns="http://docs.rackspacecloud.com/repose/system-model/v2.0">
+<system-model xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/system-model/v2.0">
   <repose-cluster id="<%= app_name %>">
     <nodes>
 <%- nodes.sort.each do |node| -%>

--- a/templates/translation.cfg.xml.erb
+++ b/templates/translation.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://wiki.openrepose.org/display/REPOSE/Translation -->
-<translation xmlns="http://docs.rackspacecloud.com/repose/translation/v1.0"
+<translation xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/translation/v1.0"
     xsl-engine="<%= xsl_engine %>" >
     <request-translations>
 <%- if @request_translations -%>

--- a/templates/uri-normalization.cfg.xml.erb
+++ b/templates/uri-normalization.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<uri-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0'
-    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0'>
+<uri-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0"
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0">
 <%- if @uri_filters -%>
     <uri-filters>
   <%- @uri_filters.each do |target| -%>

--- a/templates/uri-normalization.cfg.xml.erb
+++ b/templates/uri-normalization.cfg.xml.erb
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uri-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+       xmlns='http://docs.api.rackspacecloud.com/repose/uri-normalization/v1.0'
+       xsi:schemaLocation='http://docs.api.rackspacecloud.com/repose/uri-normalization/v1.0'>
+<%- if @uri_filters -%>
+    <uri-filters>
+  <%- @uri_filters.each do |target| -%>
+        <target
+    <%- if target.has_key?('uri-regex') -%>
+            uri-regex="<%= target['uri-regex'] %>"
+    <%- end -%>
+    <%- if target.has_key?('http-methods') -%>
+            http-methods="<%= target['http-methods'] %>"
+    <%- end -%>
+    <%- if target.has_key?('alphabetize') -%>
+            alphabetize="<%= target['alphabetize'] %>"
+    <%- end -%>
+            >
+    <%- if target.has_key?('whitelists') -%>
+      <%- target['whitelists'].each do |whitelist| -%>
+            <whitelist id="<%= whitelist['id'] %>">
+        <%- if whitelist.has_key?('parameters') -%>
+           <%- whitelist['parameters'].each do |params| -%>
+                <parameter <% params.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
+           <%- end -%>
+        <%- end -%>
+            </whitelist>
+      <%- end -%>
+    <%- end -%>
+        </target>
+  <%- end -%>
+    </uri-filters>
+<%- end -%>
+<%- if @media_types -%>
+    <media-variants>
+  <%- @media_types.each do |type| -%>
+        <media-type <% type.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
+  <%- end -%>
+    </media-variants>
+<%- end -%>
+</uri-normalization>

--- a/templates/uri-normalization.cfg.xml.erb
+++ b/templates/uri-normalization.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <uri-normalization xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-       xmlns='http://docs.api.rackspacecloud.com/repose/uri-normalization/v1.0'
-       xsi:schemaLocation='http://docs.api.rackspacecloud.com/repose/uri-normalization/v1.0'>
+    xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0'
+    xsi:schemaLocation='http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/uri-normalization/v1.0'>
 <%- if @uri_filters -%>
     <uri-filters>
   <%- @uri_filters.each do |target| -%>

--- a/templates/validator.cfg.xml.erb
+++ b/templates/validator.cfg.xml.erb
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<validators multi-role-match="<%= multi_role_match %>" xmlns="http://openrepose.org/repose/validator/v1.0"<% if ! @version.nil? %> version="<%= @version %>"<% end -%>>
+<validators
+    multi-role-match="<%= multi_role_match %>"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/validator/v1.0"<% if ! @version.nil? %> version="<%= @version %>"<% end -%>>
 <% validators.each do |validator| -%>
     <validator 
         role="<%= validator['role'] %>" 

--- a/templates/versioning.cfg.xml.erb
+++ b/templates/versioning.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://wiki.openrepose.org/display/REPOSE/Versioning+Filter -->
-<versioning xmlns="http://docs.rackspacecloud.com/repose/versioning/v2.0">
+<versioning xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/versioning/v2.0">
     <service-root href="<%= target_uri %>" />
 <%- if @version_mappings -%>
   <%- @version_mappings.each do |map| -%>


### PR DESCRIPTION
DO NOT MERGE YET.

This pull request contains items related to repose 7 configuration.  This includes:
 * log4j2 support (disabled by default).
 * uri-normalization filter (used to replace content-normalization).
 * header-normalization filter (used to replace content-normalization).
 * client-auth-n setting delegable replaced by delegating.
 * config namespace updates