### PR TITLE
Historical namespaces to fix backwards compatibility

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.4.0'
+version '1.4.1'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,8 +133,20 @@ class repose (
 ## figure out cfg namespace host
   if $cfg_new_namespace {
     $cfg_namespace_host = 'docs.openrepose.org'
+    # these are needed for historical differences in namespace hosts
+    $cfg_namespace_host_header = 'docs.openrepose.org'
+    $cfg_namespace_host_validator = 'docs.openrepose.org'
+    $cfg_namespace_host_ip = 'docs.openrepose.org'
+    $cfg_namespace_host_compression = 'docs.openrepose.org'
+    $cfg_namespace_host_dist = 'docs.openrepose.org'
   } else {
     $cfg_namespace_host = 'docs.rackspacecloud.com'
+    # these are needed for historical differences in namespace hosts
+    $cfg_namespace_host_header = 'docs.api.rackspacecloud.com'
+    $cfg_namespace_host_validator = 'openrepose.org'
+    $cfg_namespace_host_ip = 'docs.api.rackspacecloud.com'
+    $cfg_namespace_host_compression = 'docs.api.rackspacecloud.com'
+    $cfg_namespace_host_dist = 'openrepose.org'
   }
 
 ### Manage actions

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.4.0
+Version:   1.4.1
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Wed Mar 25 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.4.1-1
+- Backwards compatibility config file fixes
 * Fri Mar 20 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.4.0-1
 - Repose 7 configuration support
 * Tue Jan 20 2015 Alex Schultz <alex.schultz@rackspace.com> - 1.3.6-1

--- a/spec/defines/filter/api_validator_spec.rb
+++ b/spec/defines/filter/api_validator_spec.rb
@@ -96,7 +96,7 @@ describe 'repose::filter::api_validator', :type => :define do
 
       it {
         should contain_file('/etc/repose/validator.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/openrepose.org/)
       }
     end
 

--- a/spec/defines/filter/compression_spec.rb
+++ b/spec/defines/filter/compression_spec.rb
@@ -38,7 +38,7 @@ describe 'repose::filter::compression', :type => :define do
       let(:title) { 'default' }
       it {
         should contain_file('/etc/repose/compression.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/docs.api.rackspacecloud.com/)
       }
     end
 

--- a/spec/defines/filter/content_normalization_spec.rb
+++ b/spec/defines/filter/content_normalization_spec.rb
@@ -56,29 +56,5 @@ describe 'repose::filter::content_normalization', :type => :define do
       }
     end
 
-    context 'with defaults with old namespace' do
-      let :pre_condition do
-        "class { 'repose': cfg_new_namespace => false }"
-      end
-
-      let(:title) { 'default' }
-      it {
-        should contain_file('/etc/repose/content-normalization.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
-      }
-    end
-
-    context 'with defaults with new namespace' do
-      let :pre_condition do
-        "class { 'repose': cfg_new_namespace => true }"
-      end
-
-      let(:title) { 'default' }
-      it {
-        should contain_file('/etc/repose/content-normalization.cfg.xml').
-          with_content(/docs.openrepose.org/)
-      }
-    end
-
   end
 end

--- a/spec/defines/filter/dist_datastore_spec.rb
+++ b/spec/defines/filter/dist_datastore_spec.rb
@@ -60,7 +60,7 @@ describe 'repose::filter::dist_datastore', :type => :define do
       } }
       it {
         should contain_file('/etc/repose/dist-datastore.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/openrepose.org/)
       }
     end
 

--- a/spec/defines/filter/header_normalization_spec.rb
+++ b/spec/defines/filter/header_normalization_spec.rb
@@ -78,7 +78,7 @@ describe 'repose::filter::header_normalization', :type => :define do
       let(:title) { 'default' }
       it {
         should contain_file('/etc/repose/header-normalization.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/docs.api.rackspacecloud.com/)
       }
     end
 

--- a/spec/defines/filter/header_translation_spec.rb
+++ b/spec/defines/filter/header_translation_spec.rb
@@ -61,7 +61,7 @@ describe 'repose::filter::header_translation', :type => :define do
       let(:title) { 'default' }
       it {
         should contain_file('/etc/repose/header-translation.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/docs.api.rackspacecloud.com/)
       }
     end
 

--- a/spec/defines/filter/ip_identity_spec.rb
+++ b/spec/defines/filter/ip_identity_spec.rb
@@ -70,7 +70,7 @@ describe 'repose::filter::ip_identity', :type => :define do
       } }
       it {
         should contain_file('/etc/repose/ip-identity.cfg.xml').
-          with_content(/docs.rackspacecloud.com/)
+          with_content(/docs.api.rackspacecloud.com/)
       }
     end
 

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/client-auth/v1.0">
-    <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/client-auth/os-ids-auth/v1.0">
+    <openstack-auth <% if @delegating.nil? %>delegable="<%= @delegable %>"<% end %> tenanted="<%= @tenanted %>" group-cache-timeout="<%= @group_cache_timeout %>" <% if @connection_pool_id %>connectionPoolId="<%= @connection_pool_id %>"<% end %> <% if @token_cache_timeout %>token-cache-timeout="<%= @token_cache_timeout %>"<% end %> <% if @request_groups %>request-groups="<%= @request_groups %>"<% end %> <% if @send_all_tenant_ids %>send-all-tenant-ids="<%= @send_all_tenant_ids %>"<% end %> xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
 <%- if ! @delegating.nil? -%>
   <%- if @delegating %>
         <delegating quality="0.5"/>

--- a/templates/compression.cfg.xml.erb
+++ b/templates/compression.cfg.xml.erb
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<content-compression xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-compression/v1.0">
+<content-compression xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_compression') %>/repose/content-compression/v1.0">
     <compression compression-threshold="<%= @threshold %>" debug="<%= @debug %>" include-content-types="<%= @include_content_types.join(',') %>"<% if ! @exclude_content_types.nil? %> exclude-content-types="<%= @exclude_content_type.join(',') %>"<% end -%> />
 </content-compression>

--- a/templates/content-normalization.cfg.xml.erb
+++ b/templates/content-normalization.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <content-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/content-normalization/v1.0">
+    xmlns="http://docs.api.rackspacecloud.com/repose/content-normalization/v1.0">
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |filter| -%>

--- a/templates/dist-datastore.cfg.xml.erb
+++ b/templates/dist-datastore.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
-<distributed-datastore xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/distributed-datastore/v1.0">
+<distributed-datastore xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_dist') %>/repose/distributed-datastore/v1.0">
    <allowed-hosts allow-all="<%= allow_all %>">
       <allow host="127.0.0.1" />
 <% nodes.each do |node| -%>

--- a/templates/header-normalization.cfg.xml.erb
+++ b/templates/header-normalization.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <header-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0"
-    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd">
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_header') %>/repose/header-normalization/v1.0"
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host_header_norm') %>/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd">
 <%- if @header_filters -%>
     <header-filters>
   <%- @header_filters.each do |target| -%>

--- a/templates/header-translation.cfg.xml.erb
+++ b/templates/header-translation.cfg.xml.erb
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-translation/v1.0 ../config/header-translation.xsd"
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/header-translation/v1.0">
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host_header') %>/repose/header-translation/v1.0 ../config/header-translation.xsd"
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_header') %>/repose/header-translation/v1.0">
 <%- if @header_translations -%>
   <%- @header_translations.each do |header_translation| -%>
     <header original-name="<%= header_translation['original_name'] -%>" new-name="<%= header_translation['new_name'] -%>" remove-original="<%= header_translation['remove_original'] -%>" />

--- a/templates/ip-identity.cfg.xml.erb
+++ b/templates/ip-identity.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ip-identity  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0"
-    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/ip-identity/v1.0">
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_ip') %>/repose/ip-identity/v1.0"
+    xsi:schemaLocation="http://<%= scope.lookupvar('::repose::cfg_namespace_host_ip') %>/repose/ip-identity/v1.0">
     <quality><%= @quality %></quality>
     <white-list quality="<%= @whitelist['quality'] %>">
 <% @whitelist['addresses'].each do |address| %>

--- a/templates/validator.cfg.xml.erb
+++ b/templates/validator.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <validators
     multi-role-match="<%= multi_role_match %>"
-    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/validator/v1.0"<% if ! @version.nil? %> version="<%= @version %>"<% end -%>>
+    xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_validator') %>/repose/validator/v1.0"<% if ! @version.nil? %> version="<%= @version %>"<% end -%>>
 <% validators.each do |validator| -%>
     <validator 
         role="<%= validator['role'] %>" 


### PR DESCRIPTION
In order to properly not break < 7, we need to use the correct namespaces for some configuration files.  This PR puts those back.