### PR TITLE
CF-597: mechanism to cfg Repose's client-auth-n filter to use atom feeds for cache expiration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ before_install: rm .gemfiles/Gemfile.rspec.lock || true
 gemfile: .gemfiles/Gemfile.rspec
 
 script:
- - "bundle exec rake lint"
- - "bundle exec rake syntax"
- - "bundle exec rake spec SPEC_OPTS='--format documentation'"
+ - "bundle exec rake SPEC_OPTS='--format documentation'"
 
 env:
   - PUPPET_VERSION="~> 2.7.0"

--- a/README.rdoc
+++ b/README.rdoc
@@ -78,17 +78,26 @@ This module provides a re-usable and environment agnostic control of Repose Powe
  git clone http://github.com/rackerlabs/puppet-repose.git /etc/puppet/modules/repose
 
 ---
-== Running tests with bundler
+== Running tests 
+
+=== Requirements
+Must have:
+* ruby 2.1.5
+* rspec-core 3.1.7
+* puppet 3.7.4
+
+=== With bundler
   git clone http://github.com/rackerlabs/puppet-repose.git 
   cd puppet-repose
   bundle install
   bundle exec rake validate
   bundle exec rake spec
 
-== Running tests
+=== Straight rake
   git clone http://github.com/rackerlabs/puppet-repose.git 
   cd puppet-repose
-  gem install rspec-puppet rspec-puppet-utils puppet puppetlabs_spec_helper --no-ri --no-rdoc
+  rvm use ruby-2.1.5@repose --create
+  gem install rspec-core:3.1.7 puppet:3.7.4 rspec-puppet rspec-puppet-utils puppet puppetlabs_spec_helper puppet-lint rake --no-ri --no-rdoc
   rake validate
   rake spec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,25 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-lint/tasks/puppet-lint'
-PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-desc "Validate manifests, templates, and ruby files"
-task :validate do
-  Dir['manifests/**/*.pp'].each do |manifest|
-    sh "puppet parser validate --noop #{manifest}"
-  end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
-  end
-  Dir['templates/**/*.erb'].each do |template|
-    sh "erb -P -x -T '-' #{template} | ruby -c"
-  end
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+
+task :default => [:spec, :syntax, :lint]
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+# Disable puppet-lint checks
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send("disable_class_inherits_from_params_class")
+
+# Ignore files outside this module
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths

--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -59,6 +59,10 @@
 # from identity. NOTE: this is not valid for repose version < 6.1.x
 # Defaults to <tt>undef</tt>
 #
+# [*token_expire_feed*]
+# Optional. If set, this will configure Repose to listen to Feeds Identity
+# token revocation events. Needs a hash containing feed_url, interval.
+#
 # === Links
 #
 # * http://wiki.openrepose.org/display/REPOSE/Client+Authentication+Filter
@@ -96,6 +100,7 @@ define repose::filter::client_auth_n (
   $group_cache_timeout = '60000',
   $connection_pool_id  = undef,
   $send_all_tenant_ids = undef,
+  $token_expire_feed   = undef,
 ) {
 
 ### Validate parameters

--- a/manifests/filter/client_auth_n.pp
+++ b/manifests/filter/client_auth_n.pp
@@ -61,7 +61,8 @@
 #
 # [*token_expire_feed*]
 # Optional. If set, this will configure Repose to listen to Feeds Identity
-# token revocation events. Needs a hash containing feed_url, interval.
+# token revocation events. Needs a hash containing feed_url, interval,
+# user, pass.
 #
 # === Links
 #

--- a/manifests/filter/translation.pp
+++ b/manifests/filter/translation.pp
@@ -27,7 +27,7 @@
 # Defaults to <tt>undef</tt>
 #
 # [*xsl-engine*]
-# String.  XSL-Engine. 
+# String.  XSL-Engine.
 # Defaults to <tt>SaxonHE<tt>
 #
 # === Links

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,12 +180,12 @@ class repose (
   }
 
   file { $repose::params::configdir:
-    ensure  => $dir_ensure,
+    ensure => $dir_ensure,
   }
 
   file { '/etc/security/limits.d/repose':
-    ensure  => $file_ensure,
-    source  => 'puppet:///modules/repose/limits',
+    ensure => $file_ensure,
+    source => 'puppet:///modules/repose/limits',
   }
 
 }

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -267,6 +267,8 @@ describe 'repose::filter::client_auth_n', :type => :define do
         },
         :token_expire_feed   => {
           'feed_url' => 'https://atomvip/identity/events',
+          'user'     => 'username',
+          'pass'     => 'password',
           'interval' => '60000'
         }
       } }
@@ -278,7 +280,8 @@ describe 'repose::filter::client_auth_n', :type => :define do
         )
         should contain_file('/etc/repose/client-auth-n.cfg.xml').
           with_content(/atom-feeds check-interval=\"60000\"/).
-          with_content(/rs-identity-feed id=\"identity-token-revocation-feed\" uri=\"https:\/\/atomvip\/identity\/events\"/)
+          with_content(/rs-identity-feed id=\"identity-token-revocation-feed\" uri=\"https:\/\/atomvip\/identity\/events\"/).
+          with_content(/isAuthed=\"true\" user=\"username\" password=\"password\"/)
       }
     end
 

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -255,5 +255,32 @@ describe 'repose::filter::client_auth_n', :type => :define do
       }
     end
 
+    context 'providing token_expire_feed' do
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure              => 'present',
+        :filename            => 'client-auth-n.cfg.xml',
+        :auth                => {
+          'user' => 'username',
+          'pass' => 'password',
+          'uri'  => 'http://uri'
+        },
+        :token_expire_feed   => {
+          'feed_url' => 'https://atomvip/identity/events',
+          'interval' => '60000'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').with(
+          :ensure => 'file',
+          :owner => 'repose',
+          :group => 'repose'
+        )
+        should contain_file('/etc/repose/client-auth-n.cfg.xml').
+          with_content(/atom-feeds check-interval=\"60000\"/).
+          with_content(/rs-identity-feed id=\"identity-token-revocation-feed\" uri=\"https:\/\/atomvip\/identity\/events\"/)
+      }
+    end
+
   end
 end

--- a/spec/defines/filter/versioning_spec.rb
+++ b/spec/defines/filter/versioning_spec.rb
@@ -106,7 +106,7 @@ describe 'repose::filter::versioning', :type => :define do
       } }
       it {
         should contain_file('/etc/repose/versioning.cfg.xml').
-          with_content(/docs.openrepose.org/)
+          with_content(/localhost\/repose/)
       }
     end
 

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -14,13 +14,21 @@
   <%- end -%>
 <%- end -%>
 <%- if @ignore_tenant_roles -%>
-    <ignore-tenant-roles>
+        <ignore-tenant-roles>
   <% @ignore_tenant_roles.each do |ignore_tenant_role| -%>
-        <role><%= ignore_tenant_role %></role>
+            <role><%= ignore_tenant_role %></role>
   <%- end -%>
-    </ignore-tenant-roles>
+        </ignore-tenant-roles>
 <%- end -%>
     </openstack-auth>
+
+<%- if @token_expire_feed -%>
+    <atom-feeds check-interval="<%= @token_expire_feed['interval'] -%>">
+        <rs-identity-feed id="identity-token-revocation-feed" uri="<%= @token_expire_feed['feed_url'] -%>" 
+                          isAuthed="true" user="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>"/>
+    </atom-feeds>
+<%- end -%>
+
 <%- if @white_lists -%>
     <white-list>
   <%- @white_lists.each do |white_list| -%>

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -25,7 +25,7 @@
 <%- if @token_expire_feed -%>
     <atom-feeds check-interval="<%= @token_expire_feed['interval'] -%>">
         <rs-identity-feed id="identity-token-revocation-feed" uri="<%= @token_expire_feed['feed_url'] -%>" 
-                          isAuthed="true" user="<%= @auth['user'] -%>" password="<%= @auth['pass'] -%>"/>
+                          isAuthed="true" user="<%= @token_expire_feed['user'] -%>" password="<%= @token_expire_feed['pass'] -%>"/>
     </atom-feeds>
 <%- end -%>
 

--- a/templates/destination-router.cfg.xml.erb
+++ b/templates/destination-router.cfg.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <destination-router xmlns='http://<%= scope.lookupvar('::repose::cfg_namespace_host_destination_router') %>/repose/destination-router/v1.0'>
 <% if @targets -%>
-  <%- targets.each do |target| -%>
+  <%- @targets.each do |target| -%>
   <target id="<%= target['id'] %>" quality="<%= target['quality'] %>"/>
   <%- end -%>
 <%- end -%>

--- a/templates/dist-datastore.cfg.xml.erb
+++ b/templates/dist-datastore.cfg.xml.erb
@@ -2,15 +2,15 @@
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
 <distributed-datastore xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_dist') %>/repose/distributed-datastore/v1.0">
-   <allowed-hosts allow-all="<%= allow_all %>">
+   <allowed-hosts allow-all="<%= @allow_all %>">
       <allow host="127.0.0.1" />
-<% nodes.each do |node| -%>
+<% @nodes.each do |node| -%>
       <allow host="<%= node %>" />
 <% end -%>
    </allowed-hosts>
 <% if @port_config -%>
    <port-config>
-  <%- port_config.each do |port| -%>
+  <%- @port_config.each do |port| -%>
      <port port="<%= port['port'] %>" cluster="<%= port['cluster'] %>"<% if port.has_key?('node') %> node="<%= port['node'] %>"<% end -%> />
   <%- end -%>
    </port-config>

--- a/templates/http-logging.cfg.xml.erb
+++ b/templates/http-logging.cfg.xml.erb
@@ -5,7 +5,7 @@
     <!-- The id attribute is to help the user easily identify the log -->
     <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config
          found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
-<% log_files.each do |log_file| %>
+<% @log_files.each do |log_file| %>
     <http-log id="<%= log_file['id'] %>" format="<%= log_file['format'] %>">
         <targets><file location="<%= log_file['location'] %>"/></targets>
     </http-log>

--- a/templates/metrics.cfg.xml.erb
+++ b/templates/metrics.cfg.xml.erb
@@ -1,6 +1,6 @@
-<metrics xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/metrics/v1.0" enabled="<%= enabled %>">
+<metrics xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/metrics/v1.0" enabled="<%= @enabled %>">
     <graphite>
-    <%- graphite_servers.each do | server | -%>
+    <%- @graphite_servers.each do | server | -%>
         <server host="<%= server[ 'host' ] %>"
                 port="<%= server[ 'port' ] %>"
                 period="<%= server[ 'period' ] %>"

--- a/templates/rate-limiting.cfg.xml.erb
+++ b/templates/rate-limiting.cfg.xml.erb
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
 <rate-limiting <%- if ! @datastore.nil? %>datastore="<%= @datastore %>"<% end %> <%- if ! @overlimit_429.nil? %>overLimit-429-responseCode="<%= @overlimit_429%>"<% end %> 
-    use-capture-groups="<%= use_capture_groups %>"
+    use-capture-groups="<%= @use_capture_groups %>"
     xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/rate-limiting/v1.0">
     <!--
         Defines an endpoint with a matching regex to bind GET requests for
         returning live rate limiting information.
     -->
-    <request-endpoint uri-regex="<%= request_endpoint['uri-regex'] %>" include-absolute-limits="<%= request_endpoint['include_absolute_limits'] %>"/>
+    <request-endpoint uri-regex="<%= @request_endpoint['uri-regex'] %>" include-absolute-limits="<%= @request_endpoint['include_absolute_limits'] %>"/>
     <!-- Limits for all other requests -->
-<% limit_groups.each do |limit_group| %>
+<% @limit_groups.each do |limit_group| %>
     <limit-group id="<%= limit_group['id'] %>" groups="<%= limit_group['groups'] %>" default="<%= limit_group['default'] %>">
   <%- if limit_group.has_key?('limits') -%>
     <%- limit_group['limits'].each do |limit| %>

--- a/templates/slf4j-http-logging.cfg.xml.erb
+++ b/templates/slf4j-http-logging.cfg.xml.erb
@@ -5,7 +5,7 @@
          it can then be used in log4j backend to determin which appender to go to -->
     <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config
          found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
-<% log_files.each do |log_file| %>
+<% @log_files.each do |log_file| %>
     <slf4j-http-log 
             id="<%= log_file['id'] %>" 
             format="<%= log_file['format'] %>" />

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
 <system-model xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/system-model/v2.0">
-  <repose-cluster id="<%= app_name %>">
+  <repose-cluster id="<%= @app_name %>">
     <nodes>
-<%- nodes.sort.each do |node| -%>
-        <node id="<%= app_name %>_<%= node.split('.')[0] %>" hostname="<%= node %>"<%- if @port %> http-port="<%= port -%>"<%- end -%><%- if @https_port %> https-port="<%= https_port -%>"<%- end -%>/>
+<%- @nodes.sort.each do |node| -%>
+        <node id="<%= @app_name %>_<%= node.split('.')[0] %>" hostname="<%= node %>"<%- if @port %> http-port="<%= @port -%>"<%- end -%><%- if @https_port %> https-port="<%= @https_port -%>"<%- end -%>/>
 <%- end -%>
     </nodes>
     <filters>
-<%- filters.keys.sort.each do |key| -%>
-      <filter <% filters[key].sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
+<%- @filters.keys.sort.each do |key| -%>
+      <filter <% @filters[key].sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
 <%- end -%>
     </filters>
 <%- if ! @services.nil? %>
     <services>
-  <%- services.keys.sort.each do |key| -%>
-      <service <% services[key].sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
+  <%- @services.keys.sort.each do |key| -%>
+      <service <% @services[key].sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
   <%- end -%>
     </services>
 <%- end -%>
     <destinations>
-<%- endpoints.each do |endpoint| -%>
+<%- @endpoints.each do |endpoint| -%>
       <endpoint <% endpoint.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
 <%- end -%>
     </destinations>
@@ -29,7 +29,7 @@
   <service-cluster id="<%= @service_cluster['name'] %>">
     <nodes>
   <%- @service_cluster['nodes'].each do |endpoint| -%>
-      <node id="<%= app_name %>_<%= endpoint.split('.')[0] -%>" hostname="<%= endpoint %>" http-port="<%= port -%>"/>
+      <node id="<%= @app_name %>_<%= endpoint.split('.')[0] -%>" hostname="<%= endpoint %>" http-port="<%= port -%>"/>
   <%- end -%>
     </nodes>
   </service-cluster>

--- a/templates/translation.cfg.xml.erb
+++ b/templates/translation.cfg.xml.erb
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://wiki.openrepose.org/display/REPOSE/Translation -->
 <translation xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/translation/v1.0"
-    xsl-engine="<%= xsl_engine %>" >
+    xsl-engine="<%= @xsl_engine %>" >
     <request-translations>
 <%- if @request_translations -%>
-  <% request_translations.each do |request_translation| %>
+  <% @request_translations.each do |request_translation| %>
         <request-translation 
             http-methods="<%= request_translation['http_methods'] %>" 
             content-type="<%= request_translation['content_type'] %>" 
@@ -21,7 +21,7 @@
     </request-translations>
 <%- if @response_translations -%>
     <response-translations>
-  <% response_translations.each do |response_translation| %>
+  <% @response_translations.each do |response_translation| %>
         <response-translation 
     <%- if response_translation['code_regex'] -%>
             code-regex="<%= response_translation['code_regex'] %>"

--- a/templates/validator.cfg.xml.erb
+++ b/templates/validator.cfg.xml.erb
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <validators
-    multi-role-match="<%= multi_role_match %>"
+    multi-role-match="<%= @multi_role_match %>"
     xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host_validator') %>/repose/validator/v1.0"<% if ! @version.nil? %> version="<%= @version %>"<% end -%>>
-<% validators.each do |validator| -%>
+<% @validators.each do |validator| -%>
     <validator 
         role="<%= validator['role'] %>" 
   <%- if validator.has_key?('default') -%>

--- a/templates/versioning.cfg.xml.erb
+++ b/templates/versioning.cfg.xml.erb
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://wiki.openrepose.org/display/REPOSE/Versioning+Filter -->
 <versioning xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/versioning/v2.0">
-    <service-root href="<%= target_uri %>" />
+    <service-root href="<%= @target_uri %>" />
 <%- if @version_mappings -%>
   <%- @version_mappings.each do |map| -%>
-    <version-mapping id="<%= map['id'] %>" pp-dest-id="<%= app_name %>" status="<%= map['status'] %>">
+    <version-mapping id="<%= map['id'] %>" pp-dest-id="<%= @app_name %>" status="<%= map['status'] %>">
         <media-types>
     <%- map['media_types'].each do |type| -%>
             <media-type <% type.sort.map do |param,value| %><%= param %>="<%= value %>" <% end %>/>


### PR DESCRIPTION
This PR is to support configuring Repose's client-auth-n filter to use atom feeds for cache expiration, per the documentation here:
https://repose.atlassian.net/wiki/display/REPOSE/Client+Authentication+filter#ClientAuthenticationfilter-UsingAtomfeedsforcacheexpiration

