### PR TITLE
CF-597: auth-uri is required

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.5.0'
+version '1.5.1'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/spec/defines/filter/client_auth_n_spec.rb
+++ b/spec/defines/filter/client_auth_n_spec.rb
@@ -267,6 +267,7 @@ describe 'repose::filter::client_auth_n', :type => :define do
         },
         :token_expire_feed   => {
           'feed_url' => 'https://atomvip/identity/events',
+          'auth_url' => 'https://identity-service-url/v2.0',
           'user'     => 'username',
           'pass'     => 'password',
           'interval' => '60000'
@@ -281,7 +282,8 @@ describe 'repose::filter::client_auth_n', :type => :define do
         should contain_file('/etc/repose/client-auth-n.cfg.xml').
           with_content(/atom-feeds check-interval=\"60000\"/).
           with_content(/rs-identity-feed id=\"identity-token-revocation-feed\" uri=\"https:\/\/atomvip\/identity\/events\"/).
-          with_content(/isAuthed=\"true\" user=\"username\" password=\"password\"/)
+          with_content(/isAuthed=\"true\" auth-uri=\"https:\/\/identity-service-url\/v2.0\"/).
+          with_content(/user=\"username\" password=\"password\"/)
       }
     end
 

--- a/templates/client-auth-n.cfg.xml.erb
+++ b/templates/client-auth-n.cfg.xml.erb
@@ -24,7 +24,8 @@
 <%- if @token_expire_feed -%>
     <atom-feeds check-interval="<%= @token_expire_feed['interval'] -%>">
         <rs-identity-feed id="identity-token-revocation-feed" uri="<%= @token_expire_feed['feed_url'] -%>" 
-                          isAuthed="true" user="<%= @token_expire_feed['user'] -%>" password="<%= @token_expire_feed['pass'] -%>"/>
+                          isAuthed="true" auth-uri="<%= @token_expire_feed['auth_url'] -%>"
+                          user="<%= @token_expire_feed['user'] -%>" password="<%= @token_expire_feed['pass'] -%>"/>
     </atom-feeds>
 <%- end -%>
 


### PR DESCRIPTION
Repose wiki had the wrong sample. I didn't realize auth-uri is a required attribute if ```isAuth``` is set to true. Adding the auth-uri.