### PR TITLE
Turning off some needless logging, which is on by default.

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.6.3'
+version '1.6.4'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -138,6 +138,7 @@ if ! httpAppenders.empty?
 <%- end -%>
         </Logger>
 <%- if @herp -%>
+        <Logger name="org.openrepose.herp.pre.filter" level="warn"/>
         <Logger name="org.openrepose.herp.post.filter" level="info" additivity="false">
             <AppenderRef ref="EventLogger"/>
         </Logger>


### PR DESCRIPTION
By default, every request encountered by the herp filter is logged, which is unnecessary.

Alright, @gregswift, this should be the final one.