### PR TITLE
Change repose::filter::cors:allowed_methods param from hash to array

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '1.7.0'
+version '1.7.1'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/cors.pp
+++ b/manifests/filter/cors.pp
@@ -13,12 +13,12 @@
 # Defaults to <tt>cors.cfg.xml</tt>
 #
 # [*allowed_origins*]
-# Required - Hash of Hashes. Allows you to specify which origins are allowed
+# Required - Array of Hashes. Allows you to specify which origins are allowed
 # to request resources from this server. Nested hashes have values is_regex
 # valid values: (true | false), and origin, origin can be a regex if is_regex
 # is true, and a full string match of a URL containing port (i.e. 
 # https://www.somehost.com:443) 
-# Defaults to <tt>{ 10 => { 'is_regex' => 'true', 'origin' => '.*' }</tt>
+# Defaults to <tt>[{ 'is_regex' => 'true', 'origin' => '.*' }]</tt>
 #
 # [*allowed_methods*]
 # Array of HTTP VERBS. Allows you to specify which HTTP methods are allowed
@@ -40,7 +40,7 @@
 #
 # repose::filter::cors {
 #   'default':
-#     allowed_origins => { 10 => { 'is_regex' => 'true', 'origin' => '.*' },
+#     allowed_origins => [{ 'is_regex' => 'true', 'origin' => '.*' }],
 #     allowed_methods => [ ],
 #     resources => [ ],
 # }
@@ -53,7 +53,7 @@
 define repose::filter::cors (
   $ensure          = present,
   $filename        = 'cors.cfg.xml',
-  $allowed_origins = { 10 => { 'is_regex' => 'true', 'origin' => '.*' } },
+  $allowed_origins = [{ 'is_regex' => 'true', 'origin' => '.*' }],
   $allowed_methods = undef, 
   $resources       = undef,
 ) {

--- a/spec/defines/filter/cors_spec.rb
+++ b/spec/defines/filter/cors_spec.rb
@@ -27,18 +27,76 @@ describe 'repose::filter::cors', :type => :define do
       let(:params) { {
         :ensure     => 'present',
         :filename   => 'cors.cfg.xml',
-        :allowed_origins      => { 10 => { 'is_regex' => 'true', 'origin' => '.*' },
+        :allowed_origins => [{ 'is_regex' => 'true', 'origin' => '.*' }],
         :allowed_methods => [ ],
         :resources       => [ ],
       } }
       it {
         should contain_file('/etc/repose/cors.cfg.xml').with(
-          'ensure' => 'file',
-          'owner'  => 'repose',
-          'group'  => 'repose',
-          'mode'   => '0660').
-          with_content(/<origin regex=\"true\">\.\*\<\/origin\>/)
+          :ensure  => 'file',
+          :owner   => 'repose',
+          :group   => 'repose',
+          :mode    => '0660',
+          :content => ' <?xml version="1.0" encoding="UTF-8"?>
+<cross-origin-resource-sharing>
+    <allowed-origins>
+        <origin regex="true">.*</origin>
+    </allowed-origins>
+ 
+
+</cross-origin-resource-sharing>
+'
+        )
+      }
+    end
+    context 'providing a validator2' do
+      let(:title) { 'validator2' }
+      let(:params) { {
+        :ensure              => 'present',
+        :filename            => 'cors.cfg.xml',
+        :allowed_origins     => [{ 'is_regex' => 'true', 'origin' => '.*' }],
+        :allowed_methods     => ['OPTIONS'],
+        :resources           => [
+          {
+            'name'            => '/v2.0/tokens',
+            'comment'         => '<!-- v2.0/tokens allows for OPTIONS, POST, and GET -->',
+            'allowed_methods' => [
+              'POST',
+              'GET',
+              'OPTIONS',
+            ]
+          }
+        ]
       } }
+      it {
+        should contain_file('/etc/repose/cors.cfg.xml').with(
+          :ensure  => 'file',
+          :owner   => 'repose',
+          :group   => 'repose',
+          :mode    => '0660',
+          :content => ' <?xml version="1.0" encoding="UTF-8"?>
+<cross-origin-resource-sharing>
+    <allowed-origins>
+        <origin regex="true">.*</origin>
+    </allowed-origins>
+ 
+    <allowed-methods>
+        <method>OPTIONS</method>
+    </allowed-methods>
+
+ 
+    <resources>
+      <!-- v2.0/tokens allows for OPTIONS, POST, and GET -->
+      <resource path="/v2.0/tokens">
+      <method>POST</method>
+      <method>GET</method>
+      <method>OPTIONS</method>
+
+    </resources>
+</cross-origin-resource-sharing>
+'
+        )
+      }
     end
   end
 end

--- a/templates/cors.cfg.xml.erb
+++ b/templates/cors.cfg.xml.erb
@@ -1,7 +1,7 @@
  <?xml version="1.0" encoding="UTF-8"?>
 <cross-origin-resource-sharing>
     <allowed-origins>
-<%- @allowed_origins.keys.sort.each do | origin | -%>
+<%- @allowed_origins.each do | origin | -%>
         <origin regex="<%= origin['is_regex'] %>"><%= origin['origin'] %></origin>
 <%- end -%>
     </allowed-origins>


### PR DESCRIPTION
- The key for each nested hash is not actually used in the template.  It is only used for
ordering.  An array is an ordered list which solves for this.  It also improves readability
of the template.
- The template logic around allowed_methods was not working as expected anyways.
- Improved rspec testing around the contents of cors.cfg.xml