### PR TITLE
Add logic to fill out systemd local environment overrides

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,5 +11,11 @@ fixtures:
     java_ks:
       repo: "puppetlabs/java_ks"
       ref: "1.4.1"
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "2.6.0"
+    systemd:
+      repo: "camptocamp/systemd"
+      ref: "1.1.1"
   symlinks:
     repose: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
  - "STRICT_VARIABLES=no bundle exec rake spec SPEC_OPTS='--format documentation'"
 
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"

--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.6.0'
+version '2.7.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'
@@ -7,3 +7,4 @@ project_page 'https://github.com/rackerlabs/puppet-repose'
 dependency 'puppetlabs/stdlib', '>= 2.0.0'
 dependency 'puppetlabs/puppetlabs-java_ks', '>= 1.4.1'
 dependency 'puppetlabs/concat', '>= 1.1.0'
+dependency 'camptocamp/systemd', '>= 1.1.1'

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.6.0
+Version:   2.7.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Thu Feb 08 2017 Josh Bell <josh.bell@rackspace.com> - 2.7.0-1
+- Add systemd support for local override of service envrionment i.e. JAVA_OPTS
 * Fri Jan 26 2018 Josh Bell <josh.bell@rackspace.com> - 2.6.0-1
 - Add support to modify per filter logging levels in log4j2
 * Fri Nov 10 2017 Josh Bell <josh.bell@rackspace.com> - 2.4.0-1

--- a/spec/classes/valve_spec.rb
+++ b/spec/classes/valve_spec.rb
@@ -8,8 +8,11 @@ describe 'repose::valve' do
     }
     end
 
-    context 'with defaults for all parameters' do
-      let(:facts) { { :osfamily => 'RedHat' } }
+    context 'with defaults for all parameters on system without systemd' do
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :systemd => false,
+      } }
       it {
         should contain_class('repose').with(
           'ensure'      => 'present',
@@ -36,6 +39,22 @@ describe 'repose::valve' do
           ],
           "rm SAXON_HOME"
         ])
+      }
+    end
+
+    context 'with defaults for all parameters on system with systemd' do
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :systemd => true,
+      } }
+      it {
+        should contain_class('repose').with(
+          'ensure'      => 'present',
+          'enable'      => 'true',
+          'autoupgrade' => 'false',
+          'container'   => 'valve'
+        )
+        should contain_file('/etc/systemd/system/repose-valve.service.d/local.conf')
       }
     end
 

--- a/templates/systemd-local.conf.erb
+++ b/templates/systemd-local.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+Environment="JAVA_OPTS=<%= @java_opts.join(" ") %>"


### PR DESCRIPTION
Repose 8 package changed to using systemctl to manage the service (GOOD THING) This stopped reading `/etc/sysconfig/repose` for local overrides (OH NOES)
We need to determine the best way to have the repose module support writing this local override file for the service to override options - speficially in our case adding newrelic to the java options.

This required us to make a directory for the repose service
`mkdir /etc/systemd/system/repose-valve.service.d`

Populate it with a local.conf file containing the following
```
[Service]
Environment="JAVA_OPTS=-javaagent:/opt/newrelic/newrelic.jar -Dnewrelic.config.file=/etc/newrelic/cidm_repose.yml -Xms4096m -Xmx4096m -XX:MaxPermSize=512m"
```
Changing the service required a reload of the damons in systemctl
`systemctl daemon-reload`

Before repose-valve could be restarted with the local.conf affecting java options on start.
This from the systemctl lib file for the repose service.
```
################################################################################
#
# NOTE: This file is not intended to be edited.
#       IF you need to override any property (e.g. Environment, User, Group),
#       THEN create and/or edit: /etc/systemd/system/repose-valve.service.d/local.conf
#
# NOTE: Refer to the following for more detailed information:
#        - https://www.freedesktop.org/software/systemd/man/systemd.unit.html
#
################################################################################
 
[Unit]
Description=The Repose reverse proxy server in the stand-alone Valve configuration
After=network.target
 
[Service]
Environment="JAVA_CMD=/usr/bin/java"
Environment="JAVA_OPTS="
Environment="REPOSE_JAR=/usr/share/repose/repose-valve.jar"
Environment="REPOSE_CFG=/etc/repose"
Environment="REPOSE_OPTS="
User=repose
Group=repose
ExecStart=/usr/share/repose/repose-valve
# Java processes exit with status code 128+SIG
# SIGHUP  =  1
# SIGINT  =  2
# SIGTERM = 13
# SIGPIPE = 15
SuccessExitStatus=129 130 141 143
PrivateTmp=true
 
[Install]
WantedBy=multi-user.target
```
I am suggesting we use this module: https://forge.puppet.com/justin8/systemd
to provide a fact for conditional setup of the systemd local.conf for the repose service and to provide functionality to notify reload of systemd daemons when that file changes.