### PR TITLE
Add saml-policy filter

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,12 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "2.6.0"
+    java_ks:
+      repo: "puppetlabs/java_ks"
+      ref: "1.4.1"
   symlinks:
     repose: "#{source_dir}"

--- a/ModuleFile
+++ b/ModuleFile
@@ -5,3 +5,4 @@ filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'
 
 dependency 'puppetlabs/stdlib', '>= 2.0.0'
+dependency 'puppetlabs/puppetlabs-java_ks', '>= 1.4.1'

--- a/manifests/filter/saml_policy.pp
+++ b/manifests/filter/saml_policy.pp
@@ -1,0 +1,181 @@
+# == Resource: repose::filter::saml_policy
+#
+# This is a resource for generating uri identity filter config files
+#
+# === Parameters
+#
+# [*ensure*]
+# Bool.  Ensure config file present/absent
+# Defaults to <tt>present</tt>
+#
+# [*filename*]
+# String.  Config filename
+# Defaults to <tt>saml-policy.cfg.xml</tt>
+#
+# [*policy_bypass_issuers*]
+# Array, Optional Array of uri's of issuers. 
+# Defaults to <tt>[]</tt>
+#
+# [*keystone_uri*]
+# String, URI of the Keystone instance to use for authentication
+# Defaults to <tt></tt>
+#
+# [*keystone_user*]
+# String, username of the user to authenticate against the keystone_uri for
+# policy acquisition
+# Defaults to <tt></tt>
+#
+# [*keystone_password*]
+# String, password of the user to authenticate against the keystone_uri for
+# policy acquisition
+# Defaults to <tt></tt>
+#
+# [*keystone_pool*]
+# String, name of the pool in http_connection_pool.cfg.xml to use for making
+# requests. Optional, will use default pool if unspecified.
+# Defaults to <tt>undef</tt>
+#
+# [*policy_uri*]
+# String, URI to use for policy acquisition 
+# Defaults to <tt></tt>
+#
+# [*policy_pool*]
+# String, name of the pool in http_connection_pool.cfg.xml to use for policy
+# requests. Optional, will use default pool if unspecified.
+# Defaults to <tt>undef</tt>
+#
+# [*policy_cache_ttl*]
+# Int, Positive integer in seconds for policies time to live in the proxy cache
+# Defaults to <tt>300</tt>
+#
+# [*policy_cache_feed_id*]
+# String, The atom feed id of an atom feed that contains policy events to be
+# used for cache evictions. Policies will be evicted from the cache for all
+# three event types (i.e. CREATE, UPDATE, DELETE). This is optional, if
+# unused cache eviction will be purely off ttl.
+# Defaults to <tt>undef</tt>
+#
+# [*signature_keystore_path*]
+# String, The path to the keystore on the file system that contains the
+# certificates for signing the SAML response.
+# Defaults to <tt>/etc/pki/java/repose-saml-policy.ks</tt>
+#
+# [*signature_keystore_password*]
+# String, The password for using the keystore, defined in
+# `signature_keystore_path`
+# Defaults to <tt></tt>
+#
+# [*signature_keystore_certname*]
+# String, The name the certificate is in the keystore.
+# Defaults to <tt></tt>
+#
+# [*signature_keystore_keypass*]
+# String, The password for the certificate in the keystore.
+# Defaults to <tt></tt>
+#
+# [*signature_keystore_pem*]
+# String, PEM format certificate. 
+# Defaults to <tt></tt>
+#
+#
+# === Links
+#
+# * http://www.openrepose.org/versions/8.4.0.1/filters/saml-policy.html
+#
+# === Examples
+#
+# repose::filter::saml_policy {
+#   'default':
+#     policy_bypass_issuers       => [],
+#     keystone_uri                => 'http://keystone.somewhere.com',
+#     keystone_user               => 'aUsername',
+#     keystone_password           => 'somePassword',
+#     keystone_pool               => 'pool1',
+#     policy_uri                  => 'http://keystone.somewhere.com',
+#     policy_pool                 => 'pool2',
+#     policy_cache_ttl            => 300,
+#     policy_cache_feed_id        => 'identity-policy',
+#     signature_keystore_path     => '/etc/pki/java/repose-saml-policy.ks',
+#     signature_keystore_password => 'banana',
+#     signature_keystore_certname  => 'thingy',
+#     signature_keystore_keypass  => 'phone',
+#     signature_keystore_pem      => 'PEM_FORMAT_CERT_HERE',
+# }
+#
+# === Authors
+#
+# * Josh Bell <nailto:josh.bell@rackspace.com>
+# * c/o Cloud Identity Ops <mailto:identityops@rackspace.com>
+#
+define repose::filter::saml_policy (
+  $keystone_uri,
+  $keystone_user,
+  $keystone_password,
+  $signature_keystore_certname,
+  $signature_keystore_keypass,
+  $signature_keystore_password,
+  $signature_keystore_pem,
+  $policy_uri,
+  $keystone_pool               = undef,
+  $ensure                      = present,
+  $filename                    = 'saml-policy.cfg.xml',
+  $policy_bypass_issuers       = [],
+  $policy_cache_feed_id        = undef,
+  $policy_cache_ttl            = 300,
+  $policy_pool                 = undef,
+  $signature_keystore_path     = '/etc/pki/java/repose-saml-policy.ks',
+) {
+
+### Validate parameters
+
+## ensure
+  if ! ($ensure in [ present, absent ]) {
+    fail("\"${ensure}\" is not a valid ensure parameter value")
+  } else {
+    $file_ensure = $ensure ? {
+      present => file,
+      absent  => absent,
+    }
+  }
+  if $::debug {
+    debug("\$ensure = '${ensure}'")
+  }
+
+  if $ensure == present {
+    $content_template = template("${module_name}/saml-policy.cfg.xml.erb")
+  } else {
+    $content_template = undef
+  }
+
+## Manage actions
+  # Lay Down PEM cert on disk for java_ks to work with. 
+  file { "${repose::params::configdir}/signature_keys.pem":
+    ensure  => $file_ensure,
+    owner   => $repose::params::owner,
+    group   => $repose::params::group,
+    mode    => $repose::params::mode,
+    require => Class['::repose::package'],
+    content => $signature_keystore_pem,
+  }
+
+  java_ks { 'saml_policy_keystore':
+    ensure       => $ensure,
+    certificate  => "${repose::params::configdir}/signature_keys.pem",
+    private_key  => "${repose::params::configdir}/signature_keys.pem",
+    destkeypass  => "${signature_keystore_keypass}",
+    target       => "${signature_keystore_path}",
+    password     => "${signature_keystore_password}",
+    name         => "${signature_keystore_certname}",
+    require      => File["${repose::params::configdir}/signature_keys.pem"],
+  }
+
+  file { "${repose::params::configdir}/${filename}":
+    ensure  => $file_ensure,
+    owner   => $repose::params::owner,
+    group   => $repose::params::group,
+    mode    => $repose::params::mode,
+    require => Class['::repose::package'],
+    content => $content_template
+  }
+
+}

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   1.11.0
+Version:   1.12.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Fri Feb 24 2017 Josh Bell <josh.bell@rackspace.com> - 1.12.0-1
+- Add saml-policy filter, template and supporting tests 
 * Wed Feb 15 2017 Josh Bell <josh.bell@rackspace.com> - 1.11.0-1
 - Add option to enable intrafilter trace logging
 * Fri Jan 20 2017 Josh Bell <josh.bell@rackspace.com> - 1.10.0-1

--- a/spec/defines/filter/saml_policy_spec.rb
+++ b/spec/defines/filter/saml_policy_spec.rb
@@ -1,0 +1,205 @@
+require 'spec_helper'
+describe 'repose::filter::saml_policy', :type => :define do
+  let :pre_condition do
+    'include repose'
+  end
+  params = {
+    :ensure                      => 'present',
+    :filename                    => 'saml-policy.cfg.xml',
+    :keystone_uri                => 'http://keystone.somewhere.com',
+    :keystone_user               => 'aUsername',
+    :keystone_password           => 'somePassword',
+    :signature_keystore_certname => 'keycertname',
+    :signature_keystore_keypass  => 'keyPassword',
+    :signature_keystore_password => 'keystorePassword',
+    :signature_keystore_pem      => "-----BEGIN CERTIFICATE-----\n
+MIIEczCCA1ugAwIBAgIBADANBgkqhkiG9w0BAQQFAD..AkGA1UEBhMCR0Ix\n
+EzARBgNVBAgTClNvbWUtU3RhdGUxFDASBgNVBAoTC0..0EgTHRkMTcwNQYD\n
+VQQLEy5DbGFzcyAxIFB1YmxpYyBQcmltYXJ5IENlcn..XRpb24gQXV0aG9y\n
+aXR5MRQwEgYDVQQDEwtCZXN0IENBIEx0ZDAeFw0wMD..TUwMTZaFw0wMTAy\n
+MDQxOTUwMTZaMIGHMQswCQYDVQQGEwJHQjETMBEGA1..29tZS1TdGF0ZTEU\n
+MBIGA1UEChMLQmVzdCBDQSBMdGQxNzA1BgNVBAsTLk..DEgUHVibGljIFBy\n
+aW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFD..AMTC0Jlc3QgQ0Eg\n
+THRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCg..Tz2mr7SZiAMfQyu\n
+vBjM9OiJjRazXBZ1BjP5CE/Wm/Rr500PRK+Lh9x5eJ../ANBE0sTK0ZsDGM\n
+ak2m1g7oruI3dY3VHqIxFTz0Ta1d+NAjwnLe4nOb7/..k05ShhBrJGBKKxb\n
+8n104o/5p8HAsZPdzbFMIyNjJzBM2o5y5A13wiLitE..fyYkQzaxCw0Awzl\n
+kVHiIyCuaF4wj571pSzkv6sv+4IDMbT/XpCo8L6wTa..sh+etLD6FtTjYbb\n
+rvZ8RQM1tlKdoMHg2qxraAV++HNBYmNWs0duEdjUbJ..XI9TtnS4o1Ckj7P\n
+OfljiQIDAQABo4HnMIHkMB0GA1UdDgQWBBQ8urMCRL..5AkIp9NJHJw5TCB\n
+tAYDVR0jBIGsMIGpgBQ8urMCRLYYMHUKU5AkIp9NJH..aSBijCBhzELMAkG\n
+A1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFD..AoTC0Jlc3QgQ0Eg\n
+THRkMTcwNQYDVQQLEy5DbGFzcyAxIFB1YmxpYyBQcm..ENlcnRpZmljYXRp\n
+b24gQXV0aG9yaXR5MRQwEgYDVQQDEwtCZXN0IENBIE..DAMBgNVHRMEBTAD\n
+AQH/MA0GCSqGSIb3DQEBBAUAA4IBAQC1uYBcsSncwA..DCsQer772C2ucpX\n
+xQUE/C0pWWm6gDkwd5D0DSMDJRqV/weoZ4wC6B73f5..bLhGYHaXJeSD6Kr\n
+XcoOwLdSaGmJYslLKZB3ZIDEp0wYTGhgteb6JFiTtn..sf2xdrYfPCiIB7g\n
+BMAV7Gzdc4VspS6ljrAhbiiawdBiQlQmsBeFz9JkF4..b3l8BoGN+qMa56Y\n
+It8una2gY4l2O//on88r5IWJlm1L0oA8e4fR2yrBHX..adsGeFKkyNrwGi/\n
+7vQMfXdGsRrXNGRGnX+vWDZ3/zWI0joDtCkNnqEpVn..HoX\n 
+-----END CERTIFICATE-----",
+    :policy_uri                  => 'http://keystone.somewhere.com/puppet',
+  }
+  context 'on RedHat' do
+    let :facts do
+    {
+      :osfamily               => 'RedHat',
+      :operationsystemrelease => '6',
+    }
+    end
+
+    context 'default + sample required parameters' do
+      let(:title) { 'default' }
+      let (:params) { params }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/<keystone-credentials uri="http:\/\/keystone.somewhere.com"/).
+          with_content(/username="aUsername"/).
+          with_content(/password="somePassword"\/>/).
+          with_content(/<policy-endpoint uri="http:\/\/keystone.somewhere.com\/puppet"/). 
+          with_content(/<cache ttl="300"/).
+          with_content(/<signature-credentials keystore-filename="\/etc\/pki\/java\/repose-saml-policy.ks"/).
+          with_content(/keystore-password="keystorePassword"/). 
+          with_content(/key-name="keycertname"/).
+          with_content(/key-password="keyPassword"/) 
+        should contain_file('/etc/repose/signature_keys.pem').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/-----BEGIN CERTIFICATE-----/).
+          with_content(/-----END CERTIFICATE-----/)
+        is_expected.to contain_java_ks('saml_policy_keystore')
+      }
+    end
+
+    context 'with ensure absent' do
+      let(:title) { 'default' }
+      let (:params) { 
+        params.merge({ 
+          :ensure           => 'absent',
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with_ensure(
+          'absent')
+        should contain_file('/etc/repose/signature_keys.pem').with_ensure(
+          'absent')
+        is_expected.to contain_java_ks('saml_policy_keystore').with_ensure(
+          'absent')
+      }
+    end
+
+    context 'providing a cache ttl' do
+      let(:title) { 'user_provided_cache' }
+      let (:params) { 
+        params.merge({ 
+          :policy_cache_ttl => 500,
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/<cache ttl="500"/)
+      }
+    end
+
+    context 'providing user defined keystone pool' do
+      let(:title) { 'user_provided_keystone_pool' }
+      let (:params) { 
+        params.merge({ 
+          :keystone_pool => 'keystone_pool',
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-pool-id="keystone_pool"/)
+      }
+    end
+
+    context 'providing user defined policy pool' do
+      let(:title) { 'user_provided_policy_pool' }
+      let (:params) { 
+        params.merge({ 
+          :policy_pool   => 'policy_pool',
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-pool-id="policy_pool"/)
+      }
+    end
+
+    context 'providing user defined keystore path' do
+      let(:title) { 'user_provided_keystore_path' }
+      let (:params) { 
+        params.merge({ 
+          :signature_keystore_path => '/etc/pki/java/keystore.ks',
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/<signature-credentials keystore-filename="\/etc\/pki\/java\/keystore.ks"/)
+      }
+    end
+
+    context 'providing bypass issuers' do
+      let(:title) { 'user_provided_bypass_issures' }
+      let (:params) { 
+        params.merge({ 
+          :policy_bypass_issuers => [ 'http://www.issuer1.com',
+                                    'http://www.issuer2.com',
+                                  ],
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/<policy-bypass-issuers>/).
+          with_content(/<issuer>http:\/\/www.issuer1.com<\/issuer>/).
+          with_content(/<issuer>http:\/\/www.issuer2.com<\/issuer>/).
+          with_content(/<\/policy-bypass-issuers>/)
+      }
+    end
+
+    context 'providing a atom feed id' do
+      let(:title) { 'user_provided_bypass_issures' }
+      let (:params) { 
+        params.merge({ 
+          :policy_cache_feed_id  => 'feed_id',
+        })
+      }
+      it {
+        should contain_file('/etc/repose/saml-policy.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/atom-feed-id="feed_id"/)
+      }
+    end
+
+  end
+end

--- a/templates/saml-policy.cfg.xml.erb
+++ b/templates/saml-policy.cfg.xml.erb
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml-policy xmlns="http://docs.openrepose.org/repose/samlpolicy/v1.0">
+<%- unless @policy_bypass_issuers.empty? -%>
+    <policy-bypass-issuers> 
+  <%- @policy_bypass_issuers.each do | issuer | -%>
+        <issuer><%= issuer %></issuer>
+  <% end %>
+    </policy-bypass-issuers>
+<% end %>
+    <policy-acquisition>
+        <keystone-credentials uri="<%= @keystone_uri %>" 
+<%- if @keystone_pool -%>
+            connection-pool-id="<%= @keystone_pool %>"
+<% end %>
+            username="<%= @keystone_user %>" 
+            password="<%= @keystone_password %>"/> 
+        <policy-endpoint uri="<%= @policy_uri %>" 
+<%- if @policy_pool -%>
+            connection-pool-id="<%= @policy_pool %>"
+<% end %>
+            /> 
+        <cache ttl="<%= @policy_cache_ttl %>" 
+<%- if @policy_cache_feed_id -%>
+            atom-feed-id="<%= @policy_cache_feed_id %>"
+<% end %>
+            /> 
+    </policy-acquisition>
+    <signature-credentials keystore-filename="<%= @signature_keystore_path %>" 
+        keystore-password="<%= @signature_keystore_password %>" 
+        key-name="<%= @signature_keystore_certname %>" 
+        key-password="<%= @signature_keystore_keypass %>"/> 
+</saml-policy>


### PR DESCRIPTION
- add saml-policy filter & template
- add respect tests for saml-policy filter using dummy required attributes
- update fixtures file into the forge formatting 

Saml policy filter takes in certificate as a string and utilizes a file resource to create the PEM file for the java_ks class to create the required keystore for the filter. 