### PR TITLE
Add Tracing Header options to system model - repose 8 featue

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.3.0'
+version '2.4.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -68,6 +68,13 @@
 #   ]
 # }
 #
+# [*tracing_header*]
+# Hash with key value pairs of options for tracing header configuration
+# options found in the System Model documentation Here:
+# https://repose.atlassian.net/wiki/spaces/REPOSE/pages/526529/System+model
+# WARNING: This is a Repose version 8 and above feature only.
+# Defaults to <tt>{}</tt> Empty hash
+#
 # === Examples
 #
 # $app_name = 'repose'
@@ -93,16 +100,18 @@
 # ]
 # repose::filter::system_model {
 #   'default':
-#     app_name  => $app_name,
-#     nodes     => $app_nodes,
-#     port      => $app_port,
-#     filters   => $filters,
-#     services  => $services,
-#     endpoints => $endpoints,
+#     app_name       => $app_name,
+#     nodes          => $app_nodes,
+#     port           => $app_port,
+#     filters        => $filters,
+#     services       => $services,
+#     endpoints      => $endpoints,
+#     tracing_header => { 'enabled' => 'true' },
 # }
 #
 # === Authors
 #
+# * Josh Bell <mailto:josh.bell@rackspace.com>
 # * Alex Schultz <mailto:alex.schultz@rackspace.com>
 # * Greg Swift <mailto:greg.swift@rackspace.com>
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
@@ -119,6 +128,7 @@ define repose::filter::system_model (
   $https_port          = undef,
   $rewrite_host_header = undef,
   $service_cluster     = undef,
+  $tracing_header      = {},
 ) {
 
 ### Validate parameters

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.2.0
+Version:   2.4.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Fri Nov 10 2017 Josh Bell <josh.bell@rackspace.com> - 2.4.0-1
+- Add support for Repose 8 tracing header options
 * Thu Jul 27 2017 Geoffrey McCammon <geoff.mccammon@rackspace.com> - 2.2.0-1
 - Add connection pool ID configuration for dist datastore
 * Fri May 19 2017 Jason Straw <jason.straw@rackspace.com> - 2.1.0-1

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -200,7 +200,8 @@ describe 'repose::filter::system_model', :type => :define do
             'port'      => '80',
             'default'   => 'true'
           },
-        ]
+        ],
+        :tracing_header => { 'secondary-plain-text' => 'true' },
       } }
       it {
         should contain_file('/etc/repose/system-model.cfg.xml').with(
@@ -221,7 +222,8 @@ describe 'repose::filter::system_model', :type => :define do
           with_content(/name=\"rate-limiting\"/).
           with_content(/configuration=\"http-logging\.cfg\.xml\" name=\"http-logging\"/).
           with_content(/name=\"compression\"/).
-          with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/)
+          with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/).
+          with_content(/tracing-header secondary-plain-text=\"true\"/)
       }
     end
 

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -38,5 +38,8 @@
     </nodes>
   </service-cluster>
 <%- end -%>
+<%- if ! @tracing_header.nil? -%>
+  <tracing-header <% @tracing_header.each do | param, value| %><%= param -%>="<%= value -%>" <%end %>/>
+<%- end -%>
 </system-model>
 


### PR DESCRIPTION
- Add Tracing Header options to system model to support the Repose 8 feature. 