### PR TITLE
Add Method to provide per filter logging levels for log4j2

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.4.0'
+version '2.6.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -107,6 +107,25 @@
 # http://www.rsyslog.com/doc/master/configuration/modules/mmpstrucdata.html
 # Defaults to <tt>false</tt>.
 #
+# [*log_log4j2_optional_loggers*]
+# Hash of Hashes. A Hash of key value pairs where the key is the repose class
+# name for a filter and the value is a hash of key value paris of log4j2
+# logger fields (level is required, but optional feields can be added. level
+# can be one of `off`, `error`, `warn`, `info`, `debug`, and `trace`.
+# # Example:
+# $log_log4j2_optional_loggers: {
+#    "intrafilter-logging"  => { "level" => "trace",},
+#    "org.apache.http.wire" => { "level" => "trace", "additivity" => "true",},
+#    "org.openrepose"       => { "level" => "debug",},
+#  }
+# The attribute log_use_log4j2 must be set true for this to modify the correct
+# template.
+# Note:
+# The followg classes loggeers should not be modified as they require more
+# advanced configuration than this feature provides and they are handled
+# elsewhere. Those classes are: http, org.openrepose.herp.pre.filter and
+# org.openrepose.herp.post.filter 
+#
 # [*log_intrafilter_trace*]
 # Boolean. Adds intrafilter trace logging to repose - log_use_log4j2 must also
 # be set true.
@@ -233,54 +252,57 @@
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
 class repose::filter::container (
-  $ensure                            = present,
-  $app_name                          = undef,
-  $artifact_directory                = $repose::params::artifact_directory,
-  $artifact_directory_check_interval = 60000,
-  $client_request_logging            = undef,
-  $content_body_read_limit           = undef,
-  $deployment_directory              = $repose::params::deployment_directory,
-  $deployment_directory_auto_clean   = true,
-  $jmx_reset_time                    = undef,
-  $log_access_facility               = $repose::params::log_access_facility,
-  $log_access_app_name               = $repose::params::log_access_app_name,
-  $log_access_local                  = $repose::params::log_access_local,
-  $log_access_local_name             = $repose::params::log_access_local_name,
-  $log_access_syslog                 = $repose::params::log_access_syslog,
-  $log_dir                           = $repose::params::logdir,
-  $log_herp_app_name                 = $repose::params::log_herp_app_name,
-  $log_herp_facility                 = $repose::params::log_herp_facility,
-  $log_herp_flume                    = $repose::params::log_herp_flume,
-  $log_herp_syslog                   = $repose::params::log_herp_syslog,
-  $log_herp_syslog_postfilter        = $repose::params::log_herp_syslog_postfilter,
-  $log_herp_syslog_prefilter         = $repose::params::log_herp_syslog_prefilter,
-  $log_intrafilter_trace             = $repose::params::log_intrafilter_trace,
-  $log_level                         = $repose::params::log_level,
-  $log_local_policy                  = $repose::params::log_local_policy,
-  $log_local_size                    = $repose::params::log_local_size,
-  $log_local_rotation_count          = $repose::params::log_local_rotation_count,
-  $log_repose_facility               = $repose::params::log_repose_facility,
-  $log_use_log4j2                    = false,
-  $logging_configuration             = $repose::params::logging_configuration,
-  $ssl_enabled                       = false,
-  $ssl_keystore_filename             = undef,
-  $ssl_keystore_password             = undef,
-  $ssl_key_password                  = undef,
-  $ssl_include_cipher                = undef,
-  $ssl_exclude_cipher                = undef,
-  $syslog_server                     = undef,
-  $syslog_port                       = $repose::params::syslog_port,
-  $syslog_protocol                   = $repose::params::syslog_protocol,
-  $via                               = undef,
-  $flume_host                        = $repose::params::flume_host,
-  $flume_port                        = $repose::params::flume_port,
+  $ensure                               = present,
+  $app_name                             = undef,
+  $artifact_directory                   = $repose::params::artifact_directory,
+  $artifact_directory_check_interval    = 60000,
+  $client_request_logging               = undef,
+  $content_body_read_limit              = undef,
+  $deployment_directory                 = $repose::params::deployment_directory,
+  $deployment_directory_auto_clean      = true,
+  $jmx_reset_time                       = undef,
+  $log_access_facility                  = $repose::params::log_access_facility,
+  $log_access_app_name                  = $repose::params::log_access_app_name,
+  $log_access_local                     = $repose::params::log_access_local,
+  $log_access_local_name                = $repose::params::log_access_local_name,
+  $log_access_syslog                    = $repose::params::log_access_syslog,
+  $log_dir                              = $repose::params::logdir,
+  $log_herp_app_name                    = $repose::params::log_herp_app_name,
+  $log_herp_facility                    = $repose::params::log_herp_facility,
+  $log_herp_flume                       = $repose::params::log_herp_flume,
+  $log_herp_syslog                      = $repose::params::log_herp_syslog,
+  $log_herp_syslog_postfilter           = $repose::params::log_herp_syslog_postfilter,
+  $log_herp_syslog_prefilter            = $repose::params::log_herp_syslog_prefilter,
+  $log_log4j2_default_loggers           = $repose::params::log_log4j2_default_loggers,
+  $log_log4j2_optional_loggers          = $repose::params::log_log4j2_optional_loggers,
+  $log_log4j2_intrafilter_trace_loggers = $repose::params::log_log4j2_intrafilter_trace_loggers,
+  $log_intrafilter_trace                = $repose::params::log_intrafilter_trace,
+  $log_level                            = $repose::params::log_level,
+  $log_local_policy                     = $repose::params::log_local_policy,
+  $log_local_size                       = $repose::params::log_local_size,
+  $log_local_rotation_count             = $repose::params::log_local_rotation_count,
+  $log_repose_facility                  = $repose::params::log_repose_facility,
+  $log_use_log4j2                       = false,
+  $logging_configuration                = $repose::params::logging_configuration,
+  $ssl_enabled                          = false,
+  $ssl_keystore_filename                = undef,
+  $ssl_keystore_password                = undef,
+  $ssl_key_password                     = undef,
+  $ssl_include_cipher                   = undef,
+  $ssl_exclude_cipher                   = undef,
+  $syslog_server                        = undef,
+  $syslog_port                          = $repose::params::syslog_port,
+  $syslog_protocol                      = $repose::params::syslog_protocol,
+  $via                                  = undef,
+  $flume_host                           = $repose::params::flume_host,
+  $flume_port                           = $repose::params::flume_port,
   # BELOW ARE DEPRECATED
-  $herp                              = false,
-  $http_port                         = undef,
-  $https_port                        = undef,
-  $connection_timeout                = undef,
-  $read_timeout                      = undef,
-  $proxy_thread_pool                 = undef,
+  $herp                                 = false,
+  $http_port                            = undef,
+  $https_port                           = undef,
+  $connection_timeout                   = undef,
+  $read_timeout                         = undef,
+  $proxy_thread_pool                    = undef,
 ) inherits repose::params {
 
 ### Validate parameters
@@ -314,6 +336,12 @@ class repose::filter::container (
 
   if $log_use_log4j2 == true {
     $logging_configuration_real = 'log4j2.xml'
+    # also merge logger options hashes. 
+    if $log_intrafilter_trace == true {
+      $log_log4j2_loggers = deep_merge($log_log4j2_default_loggers, $log_log4j2_optional_loggers, $log_log4j2_intrafilter_trace_loggers)
+    } else {
+      $log_log4j2_loggers = deep_merge($log_log4j2_default_loggers, $log_log4j2_optional_loggers)
+    }
   } else {
     $logging_configuration_real = $logging_configuration
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,6 +197,29 @@ class repose::params {
 ## default access logging to syslog
   $log_access_syslog = true
 
+## default loggers and their log level for log4j2
+  $log_log4j2_default_loggers = {
+    "com.sun.jersey" => { "level" => "off",},
+    "intrafilter-logging" => { "level" => "info",},
+    "net.sf.ehcache" => { "level" => "error",},
+    "org.apache.commons.httpclient" => { "level" => "warn",},
+    "org.apache.http.wire" => { "level" => "off",},
+    "org.eclipse.jetty" => { "level" => "off",},
+    "org.openrepose" => {"level" => "info",},
+    "org.rackspace.deproxy" => { "level" => "info",},
+    "org.springframework" => { "level" => "warn", },
+  }
+
+## User defined log4j2l loggers 
+  $log_log4j2_optional_loggers = {}
+
+## Intrafilter tracing loggers 
+  $log_log4j2_intrafilter_trace_loggers = {
+    "intrafilter-logging"  => { "level" => "trace",},
+    "org.apache.http.wire" => { "level" => "trace",},
+    "org.openrepose"       => { "level" => "debug",},
+  }
+
 ## logging intrafilter trace logs
   $log_intrafilter_trace = false
 

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.5.0
+Version:   2.6.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Fri Jan 26 2018 Josh Bell <josh.bell@rackspace.com> - 2.6.0-1
+- Add support to modify per filter logging levels in log4j2
 * Fri Nov 10 2017 Josh Bell <josh.bell@rackspace.com> - 2.4.0-1
 - Add support for Repose 8 tracing header options
 * Thu Jul 27 2017 Geoffrey McCammon <geoff.mccammon@rackspace.com> - 2.2.0-1

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -123,21 +123,8 @@ end
             <AppenderRef ref="<%= appender %>"/>
 <%- end -%>
         </Root>
-        <Logger name="com.sun.jersey" level="off"/>
-        <Logger name="net.sf.ehcache" level="error"/>
-        <Logger name="org.apache.commons.httpclient" level="warn"/>
-        <Logger name="org.eclipse.jetty" level="off"/>
-        <Logger name="org.openrepose" level="info"/>
-        <Logger name="org.rackspace.deproxy" level="info"/>
-        <Logger name="org.springframework" level="warn"/>
-  <%- if @log_intrafilter_trace -%>
-        <Logger name="intrafilter-logging" level="trace"/>
-        <Logger name="org.openrepose" level="debug"/>
-        <Logger name="org.apache.http.wire" level="trace"/>
-  <%- else -%>
-        <Logger name="intrafilter-logging" level="info"/>
-        <Logger name="org.openrepose" level="info"/>
-        <Logger name="org.apache.http.wire" level="off"/>
+  <%- @log_log4j2_loggers.each do |logger, options| -%>
+        <Logger name="<%= logger -%>"<%- options.each do |key, value| -%> <%= key %>="<%= value -%>"<%- end -%>/>
   <%- end -%>
         <Logger name="http" level="info" additivity="false">
 <%-


### PR DESCRIPTION
I'm not entirely happy with this, I would like to find a way for the filter resources to provide this directly, but I didn't really see a good way to do that. 

The only improvement that I think could be made to this and might want to execute on is provide the default set of filter loggers in a separate hash and do a merge operation between the two to get a sanitized set. So you can change the default filter class logging levels. Thoughts? 