### PR TITLE
OpenTracing support

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.6.2'
+version '2.7.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/open_tracing.pp
+++ b/manifests/filter/open_tracing.pp
@@ -1,0 +1,170 @@
+# == Resource:  repose::filter::open_tracing
+#
+# This is a resource for enabling emitting traces to an OpenTracing tracer (current supports Jaeger).
+# Only usable in >= 8.8.3.0
+#
+# === Parameters
+#
+# [*ensure*]
+# Bool. Ensure config file present/absent
+# Defaults to <tt>present</tt>
+#
+# [*filename*]
+# String. Config filename.
+# Defaults to <tt>open-tracing.cfg.xml</tt>
+#
+# [*service_name*]
+# String. Application name
+# Defaults to <tt>repose</tt>
+#
+# [*connection_http*]
+# Object that sets up http connection.  Contains endpoint, username, password, and token
+# Defaults to <tt>undef</tt>
+#
+# [*endpoint*]
+# String. Set to http endpoint to push traces to.  Required if using http connection.
+# Defaults to <tt>undef</tt>
+#
+# [*username*]
+# String. Set if http endpoint requires username/password authentication.  Must be used in conjunction with password
+# Defaults to <tt>undef</tt>
+#
+# [*password*]
+# String. Set if http endpoint requires username/password authentication.  Must be used in conjunction with username
+# Defaults to <tt>undef</tt>
+#
+# [*token*]
+# String. Set if http endpoint requires token authentication.
+# Defaults to <tt>undef</tt>
+#
+# [*connection_udp*]
+# Object that sets up udp connection.  Contains host and port.
+# Defaults to <tt>undef</tt>
+#
+# [*port*]
+# Integer. Set to port the agent is listening on.
+# Defaults to <tt>undef</tt>
+#
+# [*host*]
+# String. Set to host the agent is listening on.
+# Defaults to <tt>undef</tt>
+#
+# [*sampling_constant*]
+# Object that sets constant sampling. Contains toggle attribute
+# Defaults to <tt>undef</tt>
+#
+# [*toggle*]
+# String. Set to 'off' to turn off sampling completely.  Set to 'on' to sample every trace from this service.
+# Defaults to <tt>on</tt>
+#
+# [*sampling_rate_limiting*]
+# Object that sets rate limiting sampling. Contains max_traces_per_second attribute
+# Defaults to <tt>undef</tt>
+#
+# [*max_traces_per_second*]
+# Double. Set to the maximum traces to sample per second.  If not defined, uses default of 1.0
+# Defaults to <tt>1.0</tt>
+#
+# [*sampling_probabilistic*]
+# Object that sets probabilistic sampling. Contains probability attribute
+# Defaults to <tt>undef</tt>
+#
+# [*probability*]
+# Double. Set to probability sampling rate.  Ranges from 0.0 to 1.0.  Defaults to 0.001, which is equivalent to 1 trace for every 1000 being sampled.
+# Defaults to <tt>0.001</tt>
+#
+# === Links
+#
+# * http://www.openrepose.org/versions/latest/services/open-tracing.html
+#
+# === Examples
+#
+# repsoe::filter::open_tracing {
+#  'open_tracing':
+#     service_name => 'awesome-repose',
+#     connection_http => {
+#       'endpoint' => 'https://jaeger-collector.example.com/api/traces'
+#     },
+#     sampling_constant =>  {
+#       'toggle' => 'on'
+#     }
+# }
+#
+# === Authors
+#
+# * Dimitry Ushakov <mailto:dimitry-ushakov@rackspace.com>
+#
+define repose::filter::open_tracing (
+  $ensure                 = present,
+  $filename               = 'open-tracing.cfg.xml',
+  $service_name           = 'repose',
+  $connection_http        = undef,
+  $connection_udp         = undef,
+  $sampling_constant      = undef,
+  $sampling_probabilistic = undef,
+  $sampling_rate_limiting = undef
+) {
+
+  ### Validate parameters
+
+  ## ensure
+  if ! ($ensure in [ present, absent ]) {
+    fail("\"${ensure}\" is not a valid ensure parameter value")
+  } else {
+    $file_ensure = $ensure ? {
+      present => file,
+      absent  => absent,
+    }
+  }
+  if $::debug {
+    debug("\$ensure = '${ensure}'")
+  }
+
+  if $ensure == present {
+## at least http or udp is on
+    if !$connection_http and !$connection_udp {
+      fail( 'either connection_http or connection_udp must be set' )
+    }
+
+## if http
+    if $connection_http {
+      ## must have endpoint
+      if !$connection_http['endpoint'] {
+        fail( 'must define http endpoint for connection_http' )
+      }
+
+      ## if username, then must have password and no token
+      if $connection_http['username'] {
+        if !$connection_http['password'] {
+          fail( 'must define password since username is defined for connection_http' )
+        }
+        if $connection_http['token'] {
+          fail( 'cannot define both token and username for connection_http' )
+        }        
+      }
+    } else {
+      if !$connection_udp['host'] or !$connection_udp['port'] {
+        fail( 'must specify host and port for connection_udp' )
+      }
+    }
+
+## at least one of the sampling algos must be defined
+    if !$sampling_probabilistic and !$sampling_rate_limiting and !$sampling_constant {
+      fail( 'must define at a sampling algorithm' )
+    }
+
+    $content_template = template("${module_name}/open-tracing.cfg.xml.erb")
+  } else {
+    $content_template = undef
+  }
+
+## Manage actions
+  file { "${repose::params::configdir}/${filename}":
+    ensure  => $file_ensure,
+    owner   => $repose::params::owner,
+    group   => $repose::params::group,
+    mode    => $repose::params::mode,
+    require => Class['::repose::package'],
+    content => $content_template
+  }
+}

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.6.2
+Version:   2.7.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Mon Apr 02 2018 Dimitry Ushakov <dimitry.ushakov@rackspace.com> - 2.7.0-1
+- Add opentracing module and tests
 * Wed Mar 21 2018 Meynard Alconis <meynard.alconis@rackspace.com> - 2.6.2-1
 - Fix for header user module and tests
 * Mon Mar 19 2018 Meynard Alconis <meynard.alconis@rackspace.com> - 2.6.1-1

--- a/spec/defines/filter/open_tracing_spec.rb
+++ b/spec/defines/filter/open_tracing_spec.rb
@@ -1,0 +1,474 @@
+require 'spec_helper'
+describe 'repose::filter::open_tracing', :type => :define do
+  let :pre_condition do
+    'include repose'
+  end
+  context 'on RedHat' do
+    let :facts do
+    {
+      :osfamily               => 'RedHat',
+      :operationsystemrelease => '6',
+    }
+    end
+
+    context 'default parameters' do
+      let(:title) { 'default' }
+      it {
+        should raise_error(Puppet::Error, /either connection_http or connection_udp must be set/)
+      }
+    end
+
+    context 'with ensure absent' do
+      let(:title) { 'default' }
+      let(:params) { {
+        :ensure => 'absent'
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with_ensure(
+          'absent')
+      }
+    end
+
+    context 'working parameters' do
+      let(:title) { 'working' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/<sampling-constant toggle=\"on\"/)
+      }
+    end
+
+    context 'providing http connection - no auth' do
+      let(:title) { 'connection_http_no_auth' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/<sampling-constant/)
+      }
+    end
+
+    context 'providing http connection - only username' do
+      let(:title) { 'connection_http_only_username' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'username' => 'reposeuser'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /must define password since username is defined for connection_http/)
+      }
+    end
+
+    context 'providing http connection - username + password' do
+      let(:title) { 'connection_http_username_and_password' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'username' => 'reposeuser',
+          'password' => 'reposepass'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/username=\"reposeuser\"/).
+          with_content(/password=\"reposepass\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/<sampling-constant/)
+    }
+    end
+
+    context 'providing http connection - username + password + token' do
+      let(:title) { 'connection_http_username_and_password_and_token' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'username' => 'reposeuser',
+          'password' => 'reposepass',
+          'token'    => 'mytoken'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /cannot define both token and username for connection_http/)
+      }
+    end
+
+    context 'providing http connection - only token' do
+      let(:title) { 'connection_http_only_token' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-constant toggle=\"on\"/)
+      }
+    end
+
+    context 'providing http connection - no endpoint' do
+      let(:title) { 'connection_http_no_endpoint' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'token'    => 'mytoken'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /must define http endpoint for connection_http/)
+      }
+    end
+
+    context 'providing udp connection - default' do
+      let(:title) { 'connection_udp_default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_udp => {},
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /must specify host and port for connection_udp/)
+      }
+    end
+
+    context 'providing udp connection - only host' do
+      let(:title) { 'connection_udp_only_host' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_udp => {
+          'host' => 'localhost'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /must specify host and port for connection_udp/)
+      }
+    end
+
+    context 'providing no sampling algorithm' do
+      let(:title) { 'no_sampling_algo' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_udp => {
+          'host' => 'localhost',
+          'port' => 5755
+        }
+      } }
+      it {
+        should raise_error(Puppet::Error, /must define at a sampling algorithm/)
+      }
+    end
+
+    context 'providing constant sampling - default' do
+      let(:title) { 'constant_sampling_default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_constant => {}
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-constant/)
+      }
+    end
+
+    context 'providing constant sampling - off' do
+      let(:title) { 'constant_sampling_off' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_constant => {
+          'toggle'   => 'off'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-constant toggle=\"off\"/)
+      }
+    end
+
+    context 'providing rate limiting sampling - default' do
+      let(:title) { 'rate_limiting_sampling_default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_rate_limiting => {}
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-rate-limiting/)
+      }
+    end
+
+    context 'providing rate limiting sampling - set' do
+      let(:title) { 'rate_limiting_sampling_set' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_rate_limiting => {
+          'max_traces_per_second' => '5.6'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-rate-limiting max-traces-per-second=\"5.6\"/)
+      }
+    end
+
+    context 'providing probabilistic sampling - default' do
+      let(:title) { 'probabilistic_sampling_default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_probabilistic => {}
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-probabilistic/)
+      }
+    end
+
+    context 'providing probabilistic sampling - set' do
+      let(:title) { 'probabilistic_sampling_set' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_probabilistic => {
+          'probability' => '1.0'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-probabilistic probability=\"1.0\"/)
+      }
+    end
+
+    context 'providing probabilistic and constant sampling' do
+      let(:title) { 'probabilistic_sampling_default' }
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces',
+          'token'    => 'mytoken'
+        },
+        :sampling_probabilistic => {},
+        :sampling_constant => {}
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').with(
+          'ensure' => 'file',
+          'owner'  => 'repose',
+          'group'  => 'repose',
+          'mode'   => '0660').
+          with_content(/connection-http endpoint=\"http:\/\/example.com\/api\/traces\"/).
+          with_content(/service-name=\"test-repose\"/).
+          with_content(/token=\"mytoken\"/).
+          with_content(/<sampling-constant/)
+      }
+    end
+
+    context 'with defaults with old namespace' do
+      let(:title) { 'old_namespace_default' }
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => false }"
+      end
+
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').
+          with_content(/docs.rackspacecloud.com/)
+      }
+    end
+
+    context 'with defaults with new namespace' do
+      let(:title) { 'new_namespace_default' }
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:params) { {
+        :ensure     => 'present',
+        :filename   => 'open-tracing.cfg.xml',
+        :service_name => 'test-repose',
+        :connection_http => {
+          'endpoint' => 'http://example.com/api/traces'
+        },
+        :sampling_constant => {
+          'toggle' => 'on'
+        }
+      } }
+      it {
+        should contain_file('/etc/repose/open-tracing.cfg.xml').
+          with_content(/docs.openrepose.org/)
+      }
+    end
+  end
+end

--- a/templates/open-tracing.cfg.xml.erb
+++ b/templates/open-tracing.cfg.xml.erb
@@ -1,0 +1,22 @@
+<open-tracing xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/open-tracing-service/v1.0"
+ service-name="<%= @service_name %>">
+    <jaeger>
+    <%- if @connection_http -%>
+        <connection-http endpoint="<%= @connection_http['endpoint'] %>"
+            <%- if ! @connection_http['username'].nil? -%> username="<%= @connection_http['username'] %>"<%- end -%> 
+            <%- if ! @connection_http['password'].nil? -%> password="<%= @connection_http['password'] %>"<%- end -%>
+            <%- if ! @connection_http['token'].nil? -%> token="<%= @connection_http['token'] %>"<%- end -%>
+        />
+    <%- elsif @connection_udp -%>
+        <connection-udp port="<%= @connection_udp['port'] %>" host="<%= @connection_udp['host'] %>" />
+    <%- end -%>
+    
+    <%- if @sampling_constant -%>
+        <sampling-constant <%- if ! @sampling_constant['toggle'].nil? -%>toggle="<%= @sampling_constant['toggle'] %>"<%- end -%>/>
+    <%- elsif @sampling_probabilistic -%>
+        <sampling-probabilistic <%- if ! @sampling_probabilistic['probability'].nil? -%>probability="<%= @sampling_probabilistic['probability'] %>"<%- end -%>/>
+    <%- elsif @sampling_rate_limiting -%>
+        <sampling-rate-limiting <%- if ! @sampling_rate_limiting['max_traces_per_second'].nil? -%>max-traces-per-second="<%= @sampling_rate_limiting['max_traces_per_second'] %>"<%- end -%>/>
+    <%- end -%>
+    </jaeger>
+</open-tracing>


### PR DESCRIPTION
As of version 8.8.3.0 Repose supports [OpenTracing](http://opentracing.io).

This PR adds support for this service.  For more information about Repose's
implementation of the spec, check out
http://www.openrepose.org/versions/latest/services/open-tracing.html