### PR TITLE
CIDM-1566 - Add via-header to container config

### DIFF
--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -189,7 +189,19 @@
 #
 # [*via*]
 # String. String used in the Via header.
+# Deprecated, to be removed in Repose 9.0.0.0
 # Defaults to <tt>undef</tt>
+#
+# [*via_header*]
+# Hash. Hash containing any or all of the following optional keys:
+# request-prefix, response-prefix, and/or repose-version. The keys
+# request-prefix and response-prefix are simple Strings, the key repose-version
+# is a Boolean. This can not be set at the same time as the `via` option - it
+# will result in an unparsable file by Repose.
+# Requires Repose version 8.4.1.0 or higher
+# Example:
+# via_header = { 'response-prefix' => 'Salad', 'repose-version' => 'false' }
+# Defaults to <tt>{}</tt>
 #
 # [*log_herp_flume*]
 # Enable herp filter publishing to flume.
@@ -311,6 +323,7 @@ class repose::filter::container (
   $syslog_port                          = $repose::params::syslog_port,
   $syslog_protocol                      = $repose::params::syslog_protocol,
   $via                                  = undef,
+  $via_header                           = {},
   $flume_host                           = $repose::params::flume_host,
   $flume_port                           = $repose::params::flume_port,
   # BELOW ARE DEPRECATED
@@ -349,6 +362,11 @@ class repose::filter::container (
   }
   if $::debug {
     debug("\$ensure = '${ensure}'")
+  }
+
+## error if both via options are used which would produce an unparsable config
+  if ($via and $via_header!={}) {
+    fail("The parameters \'via\' and \'via_header\' can not be used at the same time. The paramater \'via_header\' requires Repose v8.4.10 or newer.")
   }
 
   if $log_use_log4j2 == true {

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.8.0
+Version:   2.9.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Mon Dec 17 2018 Josh Bell <josh.bell@rackspace.com> - 2.9.0-1
+- Add via_header and repose_version options to container filter
 * Mon May 12 2018  Josh Bell <josh.bell@rackspace.com> - 2.8.0-1
 - Add ssl protocol and tls renegotiation options to container filter
 * Mon Apr 02 2018 Dimitry Ushakov <dimitry.ushakov@rackspace.com> - 2.7.0-1

--- a/spec/classes/filter/container_spec.rb
+++ b/spec/classes/filter/container_spec.rb
@@ -397,6 +397,18 @@ describe 'repose::filter::container' do
       }
     end
 
+    context 'define via_header option' do
+      let(:params) { {
+        :app_name => 'app',
+        :via_header => { 'response-header' => 'Salad', 'repose-version' => 'false' }
+      } }
+      it {
+        should contain_file('/etc/repose/container.cfg.xml').
+        with_content(/response-header="Salad"/).
+        with_content(/repose-version="false"/)
+      }
+    end
+
     context 'with defaults with old namespace' do
       let :pre_condition do
         "class { 'repose': cfg_new_namespace => false }"

--- a/templates/container.cfg.xml.erb
+++ b/templates/container.cfg.xml.erb
@@ -42,6 +42,14 @@
         <logging-configuration href="<%= @logging_configuration %>"/>
 <%- end -%>
 
+<%- if @via_header -%>
+    <via-header
+    <%- @via_header.each_pair do | name, value| -%>
+        <%= name %>="<%= value %>"
+    <%- end -%>
+    />
+<%- end %>
+
 <%- if @ssl_enabled == true -%>
         <ssl-configuration>
             <keystore-filename><%= @ssl_keystore_filename %></keystore-filename>


### PR DESCRIPTION
With the new behavior surrounding the via, via-header and repose-version options in container config. We found we were leaking the repose version. This updates the puppet module so we can control the via header and repose version in the user response. 