### PR TITLE
Add compression to rotated logs.

### DIFF
--- a/manifests/filter/container.pp
+++ b/manifests/filter/container.pp
@@ -92,6 +92,11 @@
 # String. The max file size for the log4j RollingFileAppender.
 # Defaults to <tt>100MB</tt>
 #
+# [*log_local_compress*]
+# String. Whether to compress the rotated log or not. 
+# Can be one of <tt>none</tt>,<tt>gz</tt>,<tt>zip</tt>
+# Defaults to <tt>none</tt>
+#
 # [*log_local_rotation_count*]
 # Integer. The number of backup files to keeo for the log4j RollingFileAppender
 # Defaults to <tt>4</tt>
@@ -294,6 +299,7 @@ class repose::filter::container (
   $log_level                            = $repose::params::log_level,
   $log_local_policy                     = $repose::params::log_local_policy,
   $log_local_size                       = $repose::params::log_local_size,
+  $log_local_compress                   = $repose::params::log_local_compress,
   $log_local_rotation_count             = $repose::params::log_local_rotation_count,
   $log_repose_facility                  = $repose::params::log_repose_facility,
   $log_use_log4j2                       = false,
@@ -337,6 +343,16 @@ class repose::filter::container (
   if ($ssl_exclude_cipher != undef) {
     validate_array($ssl_exclude_cipher)
   }
+
+## log_local_compress_ext
+  if ! ($log_local_compress in [ 'none', 'gz', 'zip' ]) {
+    fail("\"${log_local_compress}\" is not a valid log_local_compress parameter value")
+  } else {
+    $log_local_compress_ext = $log_local_compress ? {
+      'none' => '',
+      'gz'   => '.gz',
+      'zip'  => '.zip',
+    }
 
 ## ensure
   if ! ($ensure in [ present, absent ]) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -179,6 +179,9 @@ class repose::params {
 ## default local log rotation count
   $log_local_rotation_count = 4
 
+## default log local compress is 'none'
+  $log_local_compress = 'none'
+
 ## default repose.log syslog facility
   $log_repose_facility = 'local0'
 

--- a/templates/log4j2.xml.erb
+++ b/templates/log4j2.xml.erb
@@ -15,7 +15,7 @@
 <%- if @log_local_policy == 'date' -%>
         <RollingFile name="defaultFile"
             filename="<%= @log_dir-%>/<%= @app_name -%>.log"
-            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%d{yyyy-MM-dd}">
+            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%d{yyyy-MM-dd}<%= @log_local_compress_ext -%>">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
             </PatternLayout>
@@ -26,7 +26,7 @@
 <%- elsif @log_local_policy == 'size' -%>
         <RollingFile name="defaultFile"
             filename="<%= @log_dir-%>/<%= @app_name -%>.log"
-            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%i">
+            filePattern="<%= @log_dir-%>/<%= @app_name -%>.log.%i<%= @log_local_compress_ext -%>">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
             </PatternLayout>
@@ -82,7 +82,7 @@
   <%- if @log_local_policy == 'date' -%>
         <RollingFile name="httpLocal"
             filename="<%= @log_dir-%>/<%= @log_access_local_name -%>.log"
-            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%d{yyyy-MM-dd}">
+            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%d{yyyy-MM-dd}<%= @log_local_compress_ext -%>">
             <PatternLayout>
                 <Pattern>%m%n</Pattern>
             </PatternLayout>
@@ -93,7 +93,7 @@
   <%- elsif @log_local_policy == 'size' -%>
         <RollingFile name="httpLocal"
             filename="<%= @log_dir-%>/<%= @log_access_local_name -%>.log"
-            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%i">
+            filePattern="<%= @log_dir-%>/<%= @log_access_local_name -%>.log.%i<%= @log_local_compress_ext -%>">
             <PatternLayout>
                 <Pattern>%m%n</Pattern>
             </PatternLayout>


### PR DESCRIPTION
https://logging.apache.org/log4j/log4j-2.2/manual/appenders.html#RolloverStrategies

Per log4j 2.2, appending .gz or .zip to the file pattern will cause the rotated log to be compressed. This allows that to be added to the config. Defaults to 'none'.