### PR TITLE
Changes to support url encoded header in repose 9

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.11.0'
+version '2.12.0'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -137,6 +137,7 @@ define repose::filter::system_model (
   $rewrite_host_header = undef,
   $service_cluster     = undef,
   $tracing_header      = {},
+  $encoded_headers      = [],
 ) {
 
 ### Validate parameters

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -82,6 +82,9 @@
 # system-model config.
 # Defaults to <tt>false</tt> False
 #
+# [*encoded_headers*]
+# Array of header names that need to be encoded before being sent to the origin service.
+#
 # === Examples
 #
 # $app_name = 'repose'
@@ -137,7 +140,7 @@ define repose::filter::system_model (
   $rewrite_host_header = undef,
   $service_cluster     = undef,
   $tracing_header      = {},
-  $encoded_headers      = [],
+  $encoded_headers     = [],
 ) {
 
 ### Validate parameters

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.11.0
+Version:   2.12.0
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Tue Oct 22 2019 Senthil Natarajan <senthil.natarajan@rackspace.com> 2.12.0-1
+- Added support for url encoded header
 * Thu Aug 21 2019 Josh Bell <josh.bell@rackspace.com> 2.11.0-1
 - Add basic support for Repose 9 in system model and other filters
 - Add support for installing identity filter bundle

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -356,5 +356,43 @@ describe 'repose::filter::system_model', :type => :define do
           without_content(/services/)
       }
     end
+
+    context 'defaults plus setting repose9 param with encoded headers' do
+      let :pre_condition do
+        "class { 'repose': cfg_new_namespace => true }"
+      end
+
+      let(:title) { 'default' }
+      let(:params) { {
+          :ensure     => 'present',
+          :repose9    => 'true',
+          :filename   => 'system-model.cfg.xml',
+          :app_name   => 'repose',
+          :nodes      => ['app1', 'app2' ],
+          :filters    => {
+              10 => { 'name' => 'ip-identity' },
+          },
+          :endpoints  => [
+              {
+                  'id'        => 'localhost',
+                  'protocol'  => 'http',
+                  'hostname'  => 'localhost',
+                  'root-path' => '',
+                  'port'      => '80',
+                  'default'   => 'true'
+              },
+          ],
+          :encoded_headers    => ['x-user-name', 'x-rax-roles'],
+
+      } }
+      it {
+        should contain_file('/etc/repose/system-model.cfg.xml').
+                   without_content(/tracing-header/).
+                   without_content(/rewrite-host-header/).
+                   without_content(/repose-cluster/).
+                   without_content(/services/).
+                   with_content(/url-encode-headers="x-user-name,x-rax-roles"/)
+      }
+    end
   end
 end

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -27,7 +27,7 @@
   <%- end -%>
     </services>
 <%- end -%>
-    <destinations>
+    <destinations <%- if @repose9 && ! @encoded_headers.empty?  -%> url-encode-headers="<%= @encoded_headers.join(",")%>" <%- end -%> >
 <%- @endpoints.each do |endpoint| -%>
       <endpoint <% endpoint.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
 <%- end -%>


### PR DESCRIPTION
Changes:

- Added option to set the URL encoded header names in system-model for repose9