### PR TITLE
fix for repose9 still using repose-valve pid file

### DIFF
--- a/ModuleFile
+++ b/ModuleFile
@@ -1,5 +1,5 @@
 name 'citops-repose'
-version '2.12.0'
+version '2.12.1'
 description "Repose is an api middleware that provides authentication,
 filtering, ratelimitting and several other features, this deploys it."
 project_page 'https://github.com/rackerlabs/puppet-repose'

--- a/manifests/repose9.pp
+++ b/manifests/repose9.pp
@@ -55,10 +55,6 @@
 # String. Log file directory path
 # Defaults to <tt>/var/log/repose</tt>
 #
-# [*pid_file*]
-# String. Pid file location
-# Defaults to <tt>/var/run/repose-valve.pid</tt>
-#
 # [*user*]
 # String. User to run the valve as
 # Defaults to <tt>repose</tt>
@@ -129,7 +125,6 @@ class repose::repose9 (
   $run_port          = $repose::params::run_port,
   $daemon_home       = $repose::params::daemon_home,
   $log_path          = $repose::params::logdir,
-  $pid_file          = $repose::params::pid_file,
   $user              = $repose::params::user,
   $daemonize         = $repose::params::daemonize,
   $daemonize_opts    = $repose::params::daemonize_opts,
@@ -169,7 +164,6 @@ class repose::repose9 (
     "set RUN_PORT '${run_port}'",
     "set DAEMON_HOME '${daemon_home}'",
     "set LOG_PATH '${log_path}'",
-    "set PID_FILE '${pid_file}'",
     "set USER '${user}'",
     "set daemonize '${daemonize}'",
     "set daemonize_opts '\"${daemonize_opts}\"'",

--- a/puppet-module-repose.spec
+++ b/puppet-module-repose.spec
@@ -2,7 +2,7 @@
 %define base_name repose
 
 Name:      puppet-module-%{user}-%{base_name}
-Version:   2.12.0
+Version:   2.12.1
 Release:   1
 BuildArch: noarch
 Summary:   Puppet module to configure %{base_name}
@@ -30,6 +30,8 @@ cp -pr * %{buildroot}%{module_dir}/
 %{module_dir}
 
 %changelog
+* Tue Oct 29 2019 Cory Ringdahl <cory.ringdahl@rackspace.com> 2.12.1-1
+- removed PID_FILE var for repose9; startup script already takes care of this var
 * Tue Oct 22 2019 Senthil Natarajan <senthil.natarajan@rackspace.com> 2.12.0-1
 - Added support for url encoded header
 * Thu Aug 21 2019 Josh Bell <josh.bell@rackspace.com> 2.11.0-1

--- a/spec/classes/repose9_spec.rb
+++ b/spec/classes/repose9_spec.rb
@@ -26,7 +26,6 @@ describe 'repose::repose9' do
           "set RUN_PORT '9090'",
           "set DAEMON_HOME '/usr/share/lib/repose'",
           "set LOG_PATH '/var/log/repose'",
-          "set PID_FILE '/var/run/repose-valve.pid'",
           "set USER 'repose'",
           "set daemonize '/usr/sbin/daemonize'",
           "set daemonize_opts '\"-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME\"'",


### PR DESCRIPTION
startup script contains PID_FILE var based on NAME, so it's being removed from sysconfig for repose9.